### PR TITLE
Reorg: Interfaces for Tapsigner + SatsCard with some basic tap commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ ciborium = "0.2.0"
 serde = "1"
 serde_bytes = "0.11"
 secp256k1 = { version = "0.26.0", features = ["rand-std", "bitcoin-hashes-std"] }
+hex = "0.4.3"
 
 # optional dependencies
 pcsc = { version = "2", optional = true }

--- a/examples/pcsc.rs
+++ b/examples/pcsc.rs
@@ -1,7 +1,7 @@
 extern crate core;
 
 use pcsc::{Card, Context, Protocols, Scope, ShareMode, MAX_BUFFER_SIZE};
-use rust_cktap::{CardType, TapSigner, NfcTransmittor, applet_select, wait_command, read_command};
+use rust_cktap::{CardType, TapSigner, NfcTransmittor, applet_select, wait_command, read_command, SatsCard};
 use rust_cktap::commands::{AppletSelect, Error};
 
 use secp256k1::{rand, All, PublicKey, Secp256k1, SecretKey};
@@ -29,10 +29,8 @@ fn main() -> Result<(), Error> {
 
     match CardType::from_status(&status) {
         CardType::SatsCard => {
-            let rng = &mut rand::thread_rng();
-            let nonce = rand_nonce(rng).to_vec();
-            // SatsCard.read() // nonce generated in method
-            let read_response = read_command(&reader, nonce)?;
+            let mut card = SatsCard::new(reader, &status);
+            let read_response = card.read();
             dbg!(read_response);
             // TODO validate read response sig
         },

--- a/examples/pcsc.rs
+++ b/examples/pcsc.rs
@@ -6,7 +6,7 @@ use pcsc::{Card, Context, Protocols, Scope, ShareMode, MAX_BUFFER_SIZE};
 use rust_cktap::{
     AppletSelect, CertsCommand, CertsResponse, CheckCommand, CheckResponse, CommandApdu,
     DumpCommand, DumpResponse, Error, NewCommand, NewResponse, ReadCommand, ReadResponse,
-    ResponseApdu, StatusCommand, StatusResponse, WaitCommand, WaitResponse,
+    ResponseApdu, StatusCommand, StatusResponse, WaitCommand, WaitResponse, CardType, SignCommand, SignResponse
 };
 use secp256k1::ecdh::SharedSecret;
 use secp256k1::hashes::{sha256, Hash};
@@ -45,9 +45,8 @@ fn main() -> Result<(), Error> {
     //     let new_response = new_command(&card, 0, Some(chain_code.to_vec()), epubkey.serialize().to_vec(), xcvc)?;
     //     dbg!(new_response);
     // }
-
     match status.card_type() {
-        SatsCard => {
+        CardType::SatsCard => {
             let rng = &mut rand::thread_rng();
             let nonce = rand_nonce(rng).to_vec();
             // SatsCard.read() // nonce generated in method
@@ -55,14 +54,26 @@ fn main() -> Result<(), Error> {
             dbg!(read_response);
             // TODO validate read response sig
         },
-        TapSigner if status.pubkey.len() == 33 => {
-            let tapsigner = TapSigner::from_pcsc(card);
-            // tapsigner.set_cvc(cvc);
-            dbg!(tapsigner.read(&status));
+        CardType::TapSigner => {
+            let mut tapsigner = TapSigner::from_pcsc(card, &status);
+
+            if tapsigner.cvc.is_none() {
+                println!("Enter cvc:");
+                let mut cvc: String = String::new();
+                let _btye_count = std::io::stdin().read_line(&mut cvc).unwrap();
+                tapsigner.set_cvc(cvc.trim().to_owned());
+            }
             
+            let read_resp = tapsigner.read();
+            dbg!(read_resp);
             // TODO validate read response sig
-        },
-        TapSigner => { print!("TapSigner without 33 byte key") }
+            
+            // sample pulled from ref impl: https://github.com/coinkite/coinkite-tap-proto/blob/0ab18dd1446c1e21e30d04ab99c2201ccc0197f8/testing/test_crypto.py
+            let md = b"3\xa7=Q\x1f\xb3\xfa)>i\x8f\xb2\x8f6\xd2\x97\x9eW\r5\x0b\x82\x0e\xd3\xd6?\xf4G]\x14Fd";
+            let sign_resp = tapsigner.sign(md.to_vec());
+            dbg!(sign_resp);
+            // TODO validate response sig
+        }
     }
 
     // // testing authenticated commands
@@ -101,32 +112,86 @@ fn main() -> Result<(), Error> {
 
 struct TapSigner {
     card: Card,
+    pubkey: Option<PublicKey>, 
     cvc: Option<String>,
-    secp: Secp256k1<All>,
+    secp: Secp256k1<All>, // required here?
     card_nonce: Vec<u8>
 }
 
 impl TapSigner {
-    fn from_pcsc(card: Card) -> Self {
-        let rng = &mut rand::thread_rng();
-        let nonce = rand_nonce(rng).to_vec();
+    fn from_pcsc(card: Card, status: &StatusResponse) -> Self {
+        // let rng = &mut rand::thread_rng();
+        // let nonce = rand_nonce(rng).to_vec();
+        let card_nonce = &status.card_nonce;
         let mut secp: Secp256k1<All> = Secp256k1::new();
-        Self { card, cvc: None, card_nonce: nonce, secp }
+        let pubkey = if status.pubkey.len() == 33 {
+            let as_bytes = status.pubkey.as_slice();
+            Some(PublicKey::from_slice(as_bytes).unwrap()) 
+        } else {
+            None
+        };
+        Self { 
+            card, 
+            cvc: None, 
+            card_nonce: card_nonce.to_vec(), 
+            secp, 
+            pubkey 
+        }
     }
 
     fn set_cvc(&mut self, cvc: String) {
         self.cvc = Some(cvc);
     }
 
-    fn read(&self, status: &StatusResponse) -> Result<ReadResponse, Error> {
-        if let Some(cvc) = &self.cvc {
-            let (eseckey, epubkey, xcvc) =
-                calc_xcvc(&self.secp, &"read".to_string(), status, cvc);
-            read_command(&self.card, self.card_nonce.clone(), Some(epubkey), Some(xcvc))
-        } else {
-            Err(Error::PcSc("Requires CVC? No impl".to_string()))
-        }
+    fn calc_xcvc(&self, command: &String) -> (SecretKey, PublicKey, Vec<u8>) {
+        let cvc_bytes = match &self.cvc {
+            Some(cvc) => cvc.as_bytes(),
+            None => panic!("calc_xcvc requires cvc"),
+        };
+        let pubkey = match &self.pubkey {
+            Some(pk) => pk,
+            None => panic!("calc_xcvc requires a pubkey"),
+        };
+        let card_nonce_bytes = self.card_nonce.as_slice();
+        let card_nonce_command = [card_nonce_bytes, command.as_bytes()].concat();
+
+        let (eseckey, epubkey) = self.secp.generate_keypair(&mut rand::thread_rng());
+        let session_key = SharedSecret::new(&pubkey, &eseckey);
         
+        let md = sha256::Hash::hash(card_nonce_command.as_slice());
+
+        let mask: Vec<u8> = session_key
+            .as_ref()
+            .iter()
+            .zip(md.as_ref())
+            .map(|(x, y)| x ^ y)
+            .take(cvc_bytes.len())
+            .collect();
+        let xcvc = cvc_bytes.iter().zip(mask).map(|(x, y)| x ^ y).collect();
+        (eseckey, epubkey, xcvc)
+        
+    }
+
+    fn read(&mut self) -> Result<ReadResponse, Error> {
+        let (eseckey, epubkey, xcvc) = self.calc_xcvc(&"read".to_string());
+        match read_command(&self.card, self.card_nonce.clone(), Some(epubkey), Some(xcvc)) {
+            Ok(resp) => {
+                self.card_nonce = resp.card_nonce.clone();
+                Ok(resp)
+            },
+            Err(error) => panic!("Failed to read card: {:?}", error),
+        }
+    }
+
+    fn sign(&mut self, digest: Vec<u8>) -> Result<SignResponse, Error> {
+        let (eseckey, epubkey, xcvc) = self.calc_xcvc(&"sign".to_string());
+        match sign_command(&self.card, digest, epubkey, xcvc) {
+            Ok(resp) => {
+                self.card_nonce = resp.card_nonce.clone();
+                Ok(resp)
+            },
+            Err(error) => panic!("Failed to read card: {:?}", error),
+        }
     }
 }
 
@@ -164,45 +229,45 @@ fn rand_nonce(rng: &mut ThreadRng) -> [u8; 16] {
     nonce
 }
 
-fn calc_xcvc(
-    secp: &Secp256k1<All>,
-    command: &String,
-    status: &StatusResponse,
-    cvc: &String,
-) -> (SecretKey, PublicKey, Vec<u8>) {
-    dbg!(cvc);
-    assert!(6 <= cvc.len() && cvc.len() <= 32);
-    let (eseckey, epubkey) = secp.generate_keypair(&mut rand::thread_rng());
-    let cvc_bytes = cvc.as_bytes();
-    dbg!(&cvc_bytes);
-    let card_pubkey_bytes = status.pubkey.as_slice();
-    let card_pubkey: PublicKey = PublicKey::from_slice(card_pubkey_bytes).unwrap();
-    let session_key = SharedSecret::new(&card_pubkey, &eseckey);
-    let card_nonce_bytes = status.card_nonce.as_slice();
-    let card_nonce_command = [card_nonce_bytes, command.as_bytes()].concat();
-    let md = sha256::Hash::hash(card_nonce_command.as_slice());
-    let mask: Vec<u8> = session_key
-        .as_ref()
-        .iter()
-        .zip(md.as_ref())
-        .map(|(x, y)| x ^ y)
-        .take(cvc.len())
-        .collect();
-    let xcvc = cvc_bytes.iter().zip(mask).map(|(x, y)| x ^ y).collect();
-    (eseckey, epubkey, xcvc)
-}
+// fn calc_xcvc(
+//     secp: &Secp256k1<All>,
+//     command: &String,
+//     status: &StatusResponse,
+//     cvc: &String,
+// ) -> (SecretKey, PublicKey, Vec<u8>) {
+//     dbg!(cvc);
+//     assert!(6 <= cvc.len() && cvc.len() <= 32);
+//     let (eseckey, epubkey) = secp.generate_keypair(&mut rand::thread_rng());
+//     let cvc_bytes = cvc.as_bytes();
+//     dbg!(&cvc_bytes);
+//     let card_pubkey_bytes = status.pubkey.as_slice();
+//     let card_pubkey: PublicKey = PublicKey::from_slice(card_pubkey_bytes).unwrap();
+//     let session_key = SharedSecret::new(&card_pubkey, &eseckey);
+//     let card_nonce_bytes = status.card_nonce.as_slice();
+//     let card_nonce_command = [card_nonce_bytes, command.as_bytes()].concat();
+//     let md = sha256::Hash::hash(card_nonce_command.as_slice());
+//     let mask: Vec<u8> = session_key
+//         .as_ref()
+//         .iter()
+//         .zip(md.as_ref())
+//         .map(|(x, y)| x ^ y)
+//         .take(cvc.len())
+//         .collect();
+//     let xcvc = cvc_bytes.iter().zip(mask).map(|(x, y)| x ^ y).collect();
+//     (eseckey, epubkey, xcvc)
+// }
 
 fn applet_select(card: &Card) -> Result<StatusResponse, Error> {
     // Send ISO App Select.
     let applet_select_apdu = AppletSelect::default().apdu_bytes();
-    println!(
-        "Sending 'ISO Applet Select' APDU: {:?}\n",
-        &applet_select_apdu
-    );
+    // println!(
+    //     "Sending 'ISO Applet Select' APDU: {:?}\n",
+    //     &applet_select_apdu
+    // );
     let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
     let rapdu = card.transmit(&applet_select_apdu.as_slice(), &mut rapdu_buf)?;
     let status_response = StatusResponse::from_cbor(rapdu.to_vec())?;
-    println!("Received 'Status' APDU: {:?}\n", &status_response);
+    // println!("Received 'Status' APDU: {:?}\n", &status_response);
     Ok(status_response)
 }
 
@@ -260,6 +325,22 @@ fn read_command(
     let read_response = ReadResponse::from_cbor(rapdu.to_vec())?;
     println!("Received 'read' APDU: {:?}\n", &read_response);
     Ok(read_response)
+}
+
+fn sign_command(
+    card: &Card,
+    digest: Vec<u8>,
+    epubkey: PublicKey,
+    xcvc: Vec<u8>,
+) -> Result<SignResponse, Error> {
+    let command = SignCommand::for_tapsigner(Some([0,0]), digest, epubkey, xcvc);
+    println!("Sending SignCommand: {:?}\n", &command);
+    let req_apdu = command.apdu_bytes();
+    println!("Request APDU: {:?}\n", &req_apdu);
+    let mut apdu_buf = [0; MAX_BUFFER_SIZE];
+    let resp_apdu = card.transmit(&req_apdu.as_slice(), &mut apdu_buf)?;
+    let sign_response = SignResponse::from_cbor(resp_apdu.to_vec())?;
+    Ok(sign_response)
 }
 
 fn new_command(

--- a/examples/pcsc.rs
+++ b/examples/pcsc.rs
@@ -1,24 +1,19 @@
 extern crate core;
 
-use ciborium::de::from_reader;
-use ciborium::value::Value;
 use pcsc::{Card, Context, Protocols, Scope, ShareMode, MAX_BUFFER_SIZE};
-use rust_cktap::{
-    AppletSelect, CertsCommand, CertsResponse, CheckCommand, CheckResponse, CommandApdu,
-    DumpCommand, DumpResponse, Error, NewCommand, NewResponse, ReadCommand, ReadResponse,
-    ResponseApdu, StatusCommand, StatusResponse, WaitCommand, WaitResponse, CardType, SignCommand, SignResponse
-};
-use secp256k1::ecdh::SharedSecret;
-use secp256k1::hashes::{sha256, Hash};
+use rust_cktap::{CardType, TapSigner, NfcTransmittor, applet_select, wait_command, read_command};
+use rust_cktap::commands::{AppletSelect, Error};
+
+use secp256k1::{rand, All, PublicKey, Secp256k1, SecretKey};
 use secp256k1::rand::rngs::ThreadRng;
 use secp256k1::rand::Rng;
-use secp256k1::{rand, All, PublicKey, Secp256k1, SecretKey};
-use serde::Deserialize;
+// use serde_json;
+
 
 fn main() -> Result<(), Error> {
-    let card = find_first()?;
+    let reader = CardReader::find_first()?;
 
-    let status = applet_select(&card)?;
+    let status = applet_select(&reader)?;
     dbg!(&status);
 
     // TODO validate certs auth_sig
@@ -27,35 +22,22 @@ fn main() -> Result<(), Error> {
     if status.auth_delay.is_some() {
         let mut auth_delay = status.auth_delay.unwrap();
         while auth_delay > 0 {
-            let wait = wait_command(&card, None)?;
+            let wait = wait_command(&reader, None)?;
             auth_delay = wait.auth_delay;
         }
     }
 
-    // test authentication with satscard dump command
-    // let (eseckey, epubkey, xcvc) = calc_xcvc(&secp, &"dump".to_string(), &status, &satscard_cvc);
-    // let dump_response = dump_command(&card, 0, Some(epubkey.serialize().to_vec()), Some(xcvc))?;
-    // dbg!(&dump_response);
-
-    // if is a TAPSIGNER call new
-    // if status.addr.is_none() && status.tapsigner.is_some() && status.tapsigner.unwrap() == true {
-    //     let rng = &mut rand::thread_rng();
-    //     let chain_code = rand_chaincode(rng);
-    //     let (eseckey, epubkey, xcvc) = calc_xcvc(&secp, &"new".to_string(), &status, &tapsigner_cvc);
-    //     let new_response = new_command(&card, 0, Some(chain_code.to_vec()), epubkey.serialize().to_vec(), xcvc)?;
-    //     dbg!(new_response);
-    // }
-    match status.card_type() {
+    match CardType::from_status(&status) {
         CardType::SatsCard => {
             let rng = &mut rand::thread_rng();
             let nonce = rand_nonce(rng).to_vec();
             // SatsCard.read() // nonce generated in method
-            let read_response = read_command(&card, nonce, None, None)?;
+            let read_response = read_command(&reader, nonce)?;
             dbg!(read_response);
             // TODO validate read response sig
         },
         CardType::TapSigner => {
-            let mut tapsigner = TapSigner::from_pcsc(card, &status);
+            let mut tapsigner = TapSigner::new(reader, &status);
 
             if tapsigner.cvc.is_none() {
                 println!("Enter cvc:");
@@ -64,19 +46,82 @@ fn main() -> Result<(), Error> {
                 tapsigner.set_cvc(cvc.trim().to_owned());
             }
             
-            let read_resp = tapsigner.read();
-            dbg!(read_resp);
+            let read_resp = tapsigner.read()?;
+            dbg!(&read_resp);
             // TODO validate read response sig
+
+            let xpub_resp = tapsigner.xpub(true);
+            dbg!(&xpub_resp);
+            
+            let xpub_resp = tapsigner.xpub(false);
+            dbg!(&xpub_resp);
             
             // sample pulled from ref impl: https://github.com/coinkite/coinkite-tap-proto/blob/0ab18dd1446c1e21e30d04ab99c2201ccc0197f8/testing/test_crypto.py
             let md = b"3\xa7=Q\x1f\xb3\xfa)>i\x8f\xb2\x8f6\xd2\x97\x9eW\r5\x0b\x82\x0e\xd3\xd6?\xf4G]\x14Fd";
-            let sign_resp = tapsigner.sign(md.to_vec());
-            dbg!(sign_resp);
+            let sign_resp = tapsigner.sign(md.to_vec(), Some([0,0]))?;
+            dbg!(&sign_resp);
             // TODO validate response sig
         }
     }
 
-    // // testing authenticated commands
+    Ok(())
+}
+
+struct CardReader {
+    card: Card
+}
+
+impl CardReader {
+    fn find_first() -> Result<CardReader, Error> {
+        // Establish a PC/SC context.
+        let ctx = Context::establish(Scope::User)?;
+    
+        // List available readers.
+        let mut readers_buf = [0; 2048];
+        let mut readers = ctx.list_readers(&mut readers_buf)?;
+    
+        // Use the first reader.
+        let reader = match readers.next() {
+            Some(reader) => Ok(reader),
+            None => {
+                //println!("No readers are connected.");
+                Err(Error::PcSc("No readers are connected.".to_string()))
+            }
+        }?;
+        println!("Using reader: {:?}\n", reader);
+    
+        // Connect to the card.
+        let card = ctx.connect(reader, ShareMode::Shared, Protocols::ANY)?;
+
+        Ok(Self { card })
+    }
+
+    // fn get_card(&self) -> Card {
+    //     self.card
+    // }
+}
+
+impl NfcTransmittor for CardReader {
+    fn transmit(&self, send_buffer: Vec<u8>) -> Result<Vec<u8>, Error> {
+        let mut receive_buf = vec![0; MAX_BUFFER_SIZE];
+        let rapdu = self.card.transmit(&send_buffer.as_slice(), &mut receive_buf)?;
+        Ok(rapdu.to_vec())
+    }
+}
+
+fn rand_chaincode(rng: &mut ThreadRng) -> [u8; 32] {
+    let mut chain_code = [0u8; 32];
+    rng.fill(&mut chain_code);
+    chain_code
+}
+
+fn rand_nonce(rng: &mut ThreadRng) -> [u8; 16] {
+    let mut nonce = [0u8; 16];
+    rng.fill(&mut nonce);
+    nonce
+}
+
+// // testing authenticated commands
     //
     // use secp256k1::ecdh::SharedSecret;
     // use secp256k1::hashes::sha256;
@@ -107,283 +152,17 @@ fn main() -> Result<(), Error> {
 
     // byte array xor
     // let c: Vec<_> = a.iter().zip(b).map(|(x, y)| x ^ y).collect();
-    Ok(())
-}
 
-struct TapSigner {
-    card: Card,
-    pubkey: Option<PublicKey>, 
-    cvc: Option<String>,
-    secp: Secp256k1<All>, // required here?
-    card_nonce: Vec<u8>
-}
+        // test authentication with satscard dump command
+    // let (eseckey, epubkey, xcvc) = calc_xcvc(&secp, &"dump".to_string(), &status, &satscard_cvc);
+    // let dump_response = dump_command(&card, 0, Some(epubkey.serialize().to_vec()), Some(xcvc))?;
+    // dbg!(&dump_response);
 
-impl TapSigner {
-    fn from_pcsc(card: Card, status: &StatusResponse) -> Self {
-        // let rng = &mut rand::thread_rng();
-        // let nonce = rand_nonce(rng).to_vec();
-        let card_nonce = &status.card_nonce;
-        let mut secp: Secp256k1<All> = Secp256k1::new();
-        let pubkey = if status.pubkey.len() == 33 {
-            let as_bytes = status.pubkey.as_slice();
-            Some(PublicKey::from_slice(as_bytes).unwrap()) 
-        } else {
-            None
-        };
-        Self { 
-            card, 
-            cvc: None, 
-            card_nonce: card_nonce.to_vec(), 
-            secp, 
-            pubkey 
-        }
-    }
-
-    fn set_cvc(&mut self, cvc: String) {
-        self.cvc = Some(cvc);
-    }
-
-    fn calc_xcvc(&self, command: &String) -> (SecretKey, PublicKey, Vec<u8>) {
-        let cvc_bytes = match &self.cvc {
-            Some(cvc) => cvc.as_bytes(),
-            None => panic!("calc_xcvc requires cvc"),
-        };
-        let pubkey = match &self.pubkey {
-            Some(pk) => pk,
-            None => panic!("calc_xcvc requires a pubkey"),
-        };
-        let card_nonce_bytes = self.card_nonce.as_slice();
-        let card_nonce_command = [card_nonce_bytes, command.as_bytes()].concat();
-
-        let (eseckey, epubkey) = self.secp.generate_keypair(&mut rand::thread_rng());
-        let session_key = SharedSecret::new(&pubkey, &eseckey);
-        
-        let md = sha256::Hash::hash(card_nonce_command.as_slice());
-
-        let mask: Vec<u8> = session_key
-            .as_ref()
-            .iter()
-            .zip(md.as_ref())
-            .map(|(x, y)| x ^ y)
-            .take(cvc_bytes.len())
-            .collect();
-        let xcvc = cvc_bytes.iter().zip(mask).map(|(x, y)| x ^ y).collect();
-        (eseckey, epubkey, xcvc)
-        
-    }
-
-    fn read(&mut self) -> Result<ReadResponse, Error> {
-        let (eseckey, epubkey, xcvc) = self.calc_xcvc(&"read".to_string());
-        match read_command(&self.card, self.card_nonce.clone(), Some(epubkey), Some(xcvc)) {
-            Ok(resp) => {
-                self.card_nonce = resp.card_nonce.clone();
-                Ok(resp)
-            },
-            Err(error) => panic!("Failed to read card: {:?}", error),
-        }
-    }
-
-    fn sign(&mut self, digest: Vec<u8>) -> Result<SignResponse, Error> {
-        let (eseckey, epubkey, xcvc) = self.calc_xcvc(&"sign".to_string());
-        match sign_command(&self.card, digest, epubkey, xcvc) {
-            Ok(resp) => {
-                self.card_nonce = resp.card_nonce.clone();
-                Ok(resp)
-            },
-            Err(error) => panic!("Failed to read card: {:?}", error),
-        }
-    }
-}
-
-fn find_first() -> Result<Card, Error> {
-    // Establish a PC/SC context.
-    let ctx = Context::establish(Scope::User)?;
-
-    // List available readers.
-    let mut readers_buf = [0; 2048];
-    let mut readers = ctx.list_readers(&mut readers_buf)?;
-
-    // Use the first reader.
-    let reader = match readers.next() {
-        Some(reader) => Ok(reader),
-        None => {
-            //println!("No readers are connected.");
-            Err(Error::PcSc("No readers are connected.".to_string()))
-        }
-    }?;
-    println!("Using reader: {:?}\n", reader);
-
-    // Connect to the card.
-    Ok(ctx.connect(reader, ShareMode::Shared, Protocols::ANY)?)
-}
-
-fn rand_chaincode(rng: &mut ThreadRng) -> [u8; 32] {
-    let mut chain_code = [0u8; 32];
-    rng.fill(&mut chain_code);
-    chain_code
-}
-
-fn rand_nonce(rng: &mut ThreadRng) -> [u8; 16] {
-    let mut nonce = [0u8; 16];
-    rng.fill(&mut nonce);
-    nonce
-}
-
-// fn calc_xcvc(
-//     secp: &Secp256k1<All>,
-//     command: &String,
-//     status: &StatusResponse,
-//     cvc: &String,
-// ) -> (SecretKey, PublicKey, Vec<u8>) {
-//     dbg!(cvc);
-//     assert!(6 <= cvc.len() && cvc.len() <= 32);
-//     let (eseckey, epubkey) = secp.generate_keypair(&mut rand::thread_rng());
-//     let cvc_bytes = cvc.as_bytes();
-//     dbg!(&cvc_bytes);
-//     let card_pubkey_bytes = status.pubkey.as_slice();
-//     let card_pubkey: PublicKey = PublicKey::from_slice(card_pubkey_bytes).unwrap();
-//     let session_key = SharedSecret::new(&card_pubkey, &eseckey);
-//     let card_nonce_bytes = status.card_nonce.as_slice();
-//     let card_nonce_command = [card_nonce_bytes, command.as_bytes()].concat();
-//     let md = sha256::Hash::hash(card_nonce_command.as_slice());
-//     let mask: Vec<u8> = session_key
-//         .as_ref()
-//         .iter()
-//         .zip(md.as_ref())
-//         .map(|(x, y)| x ^ y)
-//         .take(cvc.len())
-//         .collect();
-//     let xcvc = cvc_bytes.iter().zip(mask).map(|(x, y)| x ^ y).collect();
-//     (eseckey, epubkey, xcvc)
-// }
-
-fn applet_select(card: &Card) -> Result<StatusResponse, Error> {
-    // Send ISO App Select.
-    let applet_select_apdu = AppletSelect::default().apdu_bytes();
-    // println!(
-    //     "Sending 'ISO Applet Select' APDU: {:?}\n",
-    //     &applet_select_apdu
-    // );
-    let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
-    let rapdu = card.transmit(&applet_select_apdu.as_slice(), &mut rapdu_buf)?;
-    let status_response = StatusResponse::from_cbor(rapdu.to_vec())?;
-    // println!("Received 'Status' APDU: {:?}\n", &status_response);
-    Ok(status_response)
-}
-
-fn status_command(card: &Card) -> Result<StatusResponse, Error> {
-    // Send 'status' command.
-    let status_apdu = StatusCommand::default().apdu_bytes();
-    println!("Sending 'status' APDU: {:?}\n", &status_apdu);
-    let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
-    let rapdu = card.transmit(&status_apdu.as_slice(), &mut rapdu_buf)?;
-    let status_response = StatusResponse::from_cbor(rapdu.to_vec())?;
-    println!("Received 'Status' APDU: {:?}\n", &status_response);
-    Ok(status_response)
-}
-
-fn certs_command(card: &Card) -> Result<CertsResponse, Error> {
-    // Send 'certs' command.
-    let certs_apdu = CertsCommand::default().apdu_bytes();
-    println!("Sending 'certs' APDU: {:?}\n", &certs_apdu);
-    let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
-    let rapdu = card.transmit(&certs_apdu.as_slice(), &mut rapdu_buf)?;
-    let certs_response = CertsResponse::from_cbor(rapdu.to_vec())?;
-    println!("Received 'Certs' APDU: {:?}\n", &certs_response);
-    println!(
-        "Received 'Certs' cert_chain: {:?}\n",
-        &certs_response.cert_chain()
-    );
-    Ok(certs_response)
-}
-
-fn check_command(card: &Card, nonce: Vec<u8>) -> Result<CheckResponse, Error> {
-    // Send 'check' command.
-    let check_apdu = CheckCommand::new(nonce).apdu_bytes();
-    println!("Sending 'check' APDU: {:?}\n", &check_apdu);
-    let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
-    let rapdu = card.transmit(&check_apdu.as_slice(), &mut rapdu_buf)?;
-    let check_response = CheckResponse::from_cbor(rapdu.to_vec())?;
-    println!("Received 'Check' APDU: {:?}\n", &check_response);
-    Ok(check_response)
-}
-
-fn read_command(
-    card: &Card,
-    card_nonce: Vec<u8>,
-    epubkey: Option<PublicKey>,
-    xcvc: Option<Vec<u8>>,
-) -> Result<ReadResponse, Error> {
-    // Send 'read' command.
-    let read_struct = ReadCommand::new(card_nonce, epubkey, xcvc);
-    //let read_struct = ReadCommand::new(status_response.card_nonce, None, None);
-    println!("Sending 'read' Struct: {:?}\n", &read_struct);
-    let read_apdu = read_struct.apdu_bytes();
-    println!("Sending 'read' APDU: {:?}\n", &read_apdu);
-    let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
-    let rapdu = card.transmit(&read_apdu.as_slice(), &mut rapdu_buf)?;
-    let read_response = ReadResponse::from_cbor(rapdu.to_vec())?;
-    println!("Received 'read' APDU: {:?}\n", &read_response);
-    Ok(read_response)
-}
-
-fn sign_command(
-    card: &Card,
-    digest: Vec<u8>,
-    epubkey: PublicKey,
-    xcvc: Vec<u8>,
-) -> Result<SignResponse, Error> {
-    let command = SignCommand::for_tapsigner(Some([0,0]), digest, epubkey, xcvc);
-    println!("Sending SignCommand: {:?}\n", &command);
-    let req_apdu = command.apdu_bytes();
-    println!("Request APDU: {:?}\n", &req_apdu);
-    let mut apdu_buf = [0; MAX_BUFFER_SIZE];
-    let resp_apdu = card.transmit(&req_apdu.as_slice(), &mut apdu_buf)?;
-    let sign_response = SignResponse::from_cbor(resp_apdu.to_vec())?;
-    Ok(sign_response)
-}
-
-fn new_command(
-    card: &Card,
-    slot: usize,
-    chain_code: Option<Vec<u8>>,
-    epubkey: Vec<u8>,
-    xcvc: Vec<u8>,
-) -> Result<NewResponse, Error> {
-    // Send 'new' command.
-    let new_apdu = NewCommand::new(slot, chain_code, epubkey, xcvc).apdu_bytes();
-    println!("Sending 'new' APDU: {:?}\n", &new_apdu);
-    let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
-    let rapdu = card.transmit(&new_apdu.as_slice(), &mut rapdu_buf)?;
-    let new_response = NewResponse::from_cbor(rapdu.to_vec())?;
-    println!("Received 'New' APDU: {:?}\n", &new_response);
-    Ok(new_response)
-}
-
-fn wait_command(card: &Card, xcvc: Option<Vec<u8>>) -> Result<WaitResponse, Error> {
-    // Send 'wait' command.
-    let wait_apdu = WaitCommand::new(None, xcvc).apdu_bytes();
-    println!("Sending 'Wait' APDU: {:?}\n", &wait_apdu);
-    let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
-    let rapdu = card.transmit(&wait_apdu.as_slice(), &mut rapdu_buf)?;
-    let wait_response = WaitResponse::from_cbor(rapdu.to_vec())?;
-    println!("Received 'Wait' APDU: {:?}\n", &wait_response);
-    Ok(wait_response)
-}
-
-fn dump_command(
-    card: &Card,
-    slot: usize,
-    epubkey: Option<Vec<u8>>,
-    xcvc: Option<Vec<u8>>,
-) -> Result<DumpResponse, Error> {
-    // Send 'dump' command
-    let dump_apdu = DumpCommand::new(slot, epubkey, xcvc).apdu_bytes();
-    println!("Sending 'dump' APDU: {:?}\n", &dump_apdu);
-    let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
-    let rapdu = card.transmit(&dump_apdu.as_slice(), &mut rapdu_buf)?;
-    let cbor_response: Value = from_reader(rapdu)?;
-    let dump_response = DumpResponse::from_cbor(rapdu.to_vec())?;
-    println!("Received 'dump' APDU: {:?}\n", &dump_response);
-    Ok(dump_response)
-}
+    // if is a TAPSIGNER call new
+    // if status.addr.is_none() && status.tapsigner.is_some() && status.tapsigner.unwrap() == true {
+    //     let rng = &mut rand::thread_rng();
+    //     let chain_code = rand_chaincode(rng);
+    //     let (eseckey, epubkey, xcvc) = calc_xcvc(&secp, &"new".to_string(), &status, &tapsigner_cvc);
+    //     let new_response = new_command(&card, 0, Some(chain_code.to_vec()), epubkey.serialize().to_vec(), xcvc)?;
+    //     dbg!(new_response);
+    // }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,749 @@
+use ciborium::de::from_reader;
+use ciborium::ser::into_writer;
+use ciborium::value::Value;
+use secp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
+use serde;
+use std::fmt;
+use std::fmt::Debug;
+
+use hex::encode;
+
+pub const APP_ID: [u8; 15] = *b"\xf0CoinkiteCARDv1";
+pub const SELECT_CLA_INS_P1P2: [u8; 4] = [0x00, 0xA4, 0x04, 0x00];
+pub const CBOR_CLA_INS_P1P2: [u8; 4] = [0x00, 0xCB, 0x00, 0x00];
+
+// require nonce sizes (bytes)
+pub const CARD_NONCE_SIZE: usize = 16;
+pub const USER_NONCE_SIZE: usize = 16;
+
+// Errors
+#[derive(Debug)]
+pub enum Error {
+    CiborDe(String),
+    CiborValue(String),
+    CkTap {
+        error: String,
+        code: usize,
+    },
+    #[cfg(feature = "pcsc")]
+    PcSc(String),
+}
+
+impl<T> From<ciborium::de::Error<T>> for Error
+where
+    T: core::fmt::Debug,
+{
+    fn from(e: ciborium::de::Error<T>) -> Self {
+        Error::CiborDe(e.to_string())
+    }
+}
+
+impl From<ciborium::value::Error> for Error {
+    fn from(e: ciborium::value::Error) -> Self {
+        Error::CiborDe(e.to_string())
+    }
+}
+
+#[cfg(feature = "pcsc")]
+impl From<pcsc::Error> for Error {
+    fn from(e: pcsc::Error) -> Self {
+        Error::PcSc(e.to_string())
+    }
+}
+
+// Apdu Traits
+
+pub trait CommandApdu {
+    fn apdu_bytes(&self) -> Vec<u8>
+    where
+        Self: serde::Serialize,
+    {
+        let mut command = Vec::new();
+        into_writer(&self, &mut command).unwrap();
+        build_apdu(&CBOR_CLA_INS_P1P2, command.as_slice())
+    }
+}
+
+pub trait ResponseApdu {
+    fn from_cbor<'a>(cbor: Vec<u8>) -> Result<Self, Error>
+    where
+        Self: Deserialize<'a> + Debug,
+    {
+        let cbor_value: Value = from_reader(&cbor[..])?;
+        let cbor_struct: Result<ErrorResponse, _> = cbor_value.deserialized();
+        if let Ok(error_resp) = cbor_struct {
+            Err(Error::CkTap {
+                error: error_resp.error,
+                code: error_resp.code,
+            })?;
+        }
+        let cbor_struct: Self = cbor_value.deserialized()?;
+        Ok(cbor_struct)
+    }
+}
+
+fn build_apdu(header: &[u8], command: &[u8]) -> Vec<u8> {
+    let command_len = command.len();
+    assert!(command_len <= 255, "apdu command too long"); // TODO use Err
+    [header, &[command_len as u8], command].concat()
+}
+
+/// Applet Select
+///
+#[derive(Default, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct AppletSelect {}
+
+impl CommandApdu for AppletSelect {
+    fn apdu_bytes(&self) -> Vec<u8> {
+        build_apdu(&SELECT_CLA_INS_P1P2, &APP_ID)
+    }
+}
+
+/// Status Command
+///
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct StatusCommand {
+    /// 'status' command
+    cmd: String,
+}
+
+impl Default for StatusCommand {
+    fn default() -> Self {
+        StatusCommand {
+            cmd: "status".to_string(),
+        }
+    }
+}
+
+impl CommandApdu for StatusCommand {}
+
+/// Read Command
+///
+/// Apps need to write a CBOR message to read a SATSCARD's current payment address, or a
+/// TAPSIGNER's derived public key.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct ReadCommand {
+    /// 'read' command
+    cmd: String,
+    /// provided by app, cannot be all same byte (& should be random), 16 bytes
+    #[serde(with = "serde_bytes")]
+    nonce: Vec<u8>,
+    /// (TAPSIGNER only) auth is required, 33 bytes
+    #[serde(with = "serde_bytes")]
+    epubkey: Option<Vec<u8>>,
+    /// (TAPSIGNER only) auth is required encrypted CVC value, 6 to 32 bytes
+    #[serde(with = "serde_bytes")]
+    xcvc: Option<Vec<u8>>,
+}
+
+impl ReadCommand {
+    pub fn for_tapsigner(nonce: Vec<u8>, epubkey: PublicKey, xcvc: Vec<u8>) -> Self {
+        ReadCommand {
+            cmd: "read".to_string(),
+            nonce,
+            epubkey: Some(epubkey.serialize().to_vec()),
+            xcvc: Some(xcvc),
+        }
+    }
+
+    pub fn for_satscard(nonce: Vec<u8>) -> Self {
+        ReadCommand {
+            cmd: "read".to_string(),
+            nonce,
+            epubkey: None,
+            xcvc: None,
+        }
+    } 
+}
+
+impl CommandApdu for ReadCommand {}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct DeriveCommand {
+    cmd: String,
+    /// provided by app, cannot be all same byte (& should be random), 16 bytes
+    #[serde(with = "serde_bytes")]
+    nonce: Vec<u8>,
+}
+
+/// nfc command to return dynamic url for NFC-enabled smart phone
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct NfcCommand {
+    cmd: String,
+}
+
+impl Default for NfcCommand {
+    fn default() -> Self {
+        Self {
+            cmd: "nfc".to_string(),
+        }
+    }
+}
+
+impl CommandApdu for NfcCommand {}
+
+/// Sign Command
+/// {
+//     'cmd': 'sign',              # command
+//     'slot': 0,                  # (optional) which slot's to key to use, must be unsealed.
+//     'subpath': [0, 0],          # (TAPSIGNER only) additional derivation keypath to be used
+//     'digest': (32 bytes),        # message digest to be signed
+//     'epubkey': (33 bytes),       # app's ephemeral public key
+//     'xcvc': (6 bytes)          # encrypted CVC value
+// }
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct SignCommand {
+    cmd: String,
+    slot: Option<u8>,
+    subpath: Option<[u32; 2]>, // additional keypath for TapSigner only
+    #[serde(with = "serde_bytes")]
+    digest: Vec<u8>, // message digest to be signed
+    #[serde(with = "serde_bytes")]
+    epubkey: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    xcvc: Vec<u8>,
+}
+
+impl SignCommand {
+    // pub fn for_satscard(slot: Option<u8>, digest: Vec<u8>, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
+    //     Self {
+    //         cmd: "sign".to_string(),
+    //         slot,
+    //         digest,
+    //         subpath: None,
+    //         epubkey,
+    //         xcvc,
+    //     }
+    // }
+
+    pub fn for_tapsigner(subpath: Option<[u32; 2]>, digest: Vec<u8>, epubkey: PublicKey, xcvc: Vec<u8>) -> Self {
+        SignCommand {
+            cmd: "sign".to_string(),
+            slot: Some(0),
+            subpath,
+            digest,
+            epubkey: epubkey.serialize().to_vec(),
+            xcvc,
+        }
+    }
+}
+
+impl CommandApdu for SignCommand {}
+
+/// Wait Command
+///
+/// Invalid CVC codes return error 401 (bad auth), through the third incorrect attempt. After the
+/// third incorrect attempt, a 15-second delay is required. Any further attempts to authenticate
+/// will return error 429 (rate limited) until the delay has passed.
+///
+/// In rate-limiting mode, the status command returns the auth_delay field with a positive value.
+///
+/// The wait command takes one second to execute and reduces the auth_delay by one unit. Typically,
+/// 15 wait commands need to be executed before retrying a CVC.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct WaitCommand {
+    /// 'wait' command
+    cmd: String,
+    /// app's ephemeral public key (optional)
+    #[serde(with = "serde_bytes")]
+    epubkey: Option<Vec<u8>>,
+    /// encrypted CVC value (optional), 6 to 32 bytes
+    #[serde(with = "serde_bytes")]
+    xcvc: Option<Vec<u8>>,
+}
+
+impl WaitCommand {
+    pub fn new(epubkey: Option<Vec<u8>>, xcvc: Option<Vec<u8>>) -> Self {
+        WaitCommand {
+            cmd: "wait".to_string(),
+            epubkey,
+            xcvc,
+        }
+    }
+}
+
+impl CommandApdu for WaitCommand {}
+
+/// Certs Command
+///
+/// This command is used to verify the card was made by Coinkite and is not counterfeit. Two
+/// requests are needed: first, fetch the certificates, and then provide a nonce to be signed.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct CertsCommand {
+    /// 'certs' command
+    cmd: String,
+}
+
+impl Default for CertsCommand {
+    fn default() -> Self {
+        CertsCommand {
+            cmd: "certs".to_string(),
+        }
+    }
+}
+
+impl CommandApdu for CertsCommand {}
+
+/// Check Command
+///
+/// This command is used to verify the card was made by Coinkite and is not counterfeit. Two
+/// requests are needed: first, fetch the certificates, and then provide a nonce to be signed.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct CheckCommand {
+    /// 'check' command
+    cmd: String,
+    /// random value from app, 16 bytes
+    #[serde(with = "serde_bytes")]
+    nonce: Vec<u8>,
+}
+
+impl CheckCommand {
+    pub fn new(nonce: Vec<u8>) -> Self {
+        CheckCommand {
+            cmd: "check".to_string(),
+            nonce,
+        }
+    }
+}
+
+impl CommandApdu for CheckCommand {}
+
+/// New Command
+///
+/// SATSCARD: Use this command to pick a new private key and start a fresh slot. The operation cannot be performed if the current slot is sealed.
+///
+/// TAPSIGNER: This command is only used once.
+///
+/// The slot number is included in the request to prevent command replay.
+///
+/// At this point:
+///
+///     No new slots available? Abort and fail command.
+///     A new key pair is picked and stored into the new slot.
+///         The chain_code must be used in that process and stored.
+///         The card uses TRNG to pick a new master_pubkey (pair).
+///
+/// The new values take effect immediately, so some fields of the next status response will have
+/// new values.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct NewCommand {
+    /// 'new' command
+    cmd: String,
+    /// (optional: default zero) slot to be affected, must equal currently-active slot number
+    slot: usize,
+    /// app's entropy share to be applied to new slot (optional on SATSCARD), 32 bytes
+    #[serde(with = "serde_bytes")]
+    chain_code: Option<Vec<u8>>,
+    /// app's ephemeral public key, 33 bytes
+    #[serde(with = "serde_bytes")]
+    epubkey: Vec<u8>,
+    /// encrypted CVC value, 6 bytes
+    #[serde(with = "serde_bytes")]
+    xcvc: Vec<u8>,
+}
+
+impl NewCommand {
+    pub fn new(slot: usize, chain_code: Option<Vec<u8>>, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
+        NewCommand {
+            cmd: "new".to_string(),
+            slot,
+            chain_code,
+            epubkey,
+            xcvc,
+        }
+    }
+}
+
+impl CommandApdu for NewCommand {}
+
+/// Dump Command
+///
+/// This reveals the details for any slot. The current slot is not affected. This is a no-op in
+/// terms of response content, if slots aren't available yet, or if a slot hasn't been unsealed.
+/// The factory uses this to verify the CVC is printed correctly without side effects.
+///
+/// If the epubkey or xcvc is absent, the command still works, but the no sensitive information is
+/// shared.
+///
+/// Incorrect auth values for xcvc will fail as normal. Omit the xcvc and epubkey value to proceed
+/// without authentication if CVC is unknown.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct DumpCommand {
+    /// 'dump' command
+    cmd: String,
+    /// which slot to dump, must be unsealed.
+    slot: usize,
+    /// app's ephemeral public key (optional), 33 bytes
+    #[serde(with = "serde_bytes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    epubkey: Option<Vec<u8>>,
+    /// encrypted CVC value (optional), 6 bytes
+    #[serde(with = "serde_bytes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    xcvc: Option<Vec<u8>>,
+}
+
+impl DumpCommand {
+    pub fn new(slot: usize, epubkey: Option<Vec<u8>>, xcvc: Option<Vec<u8>>) -> Self {
+        DumpCommand {
+            cmd: "dump".to_string(),
+            slot,
+            epubkey,
+            xcvc,
+        }
+    }
+}
+
+impl CommandApdu for DumpCommand {}
+
+
+// TAPSIGNER only - Provides the current XPUB (BIP-32 serialized), either at the top level (master) or the derived key in use (see 'path' value in status response)
+// {
+//     'cmd': 'xpub',              # command
+//     'master': (boolean),        # give master (`m`) XPUB, otherwise derived XPUB
+//     'epubkey': (33 bytes),       # app's ephemeral public key (required)
+//     'xcvc': (6 bytes)          # encrypted CVC value (required)
+// }
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct XpubCommand {
+    cmd: String,
+    master: bool,
+    #[serde(with = "serde_bytes")]
+    epubkey: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    xcvc: Vec<u8>
+}
+
+impl CommandApdu for XpubCommand {}
+
+impl XpubCommand {
+    pub fn new(master: bool, epubkey: PublicKey, xcvc: Vec<u8>) -> Self {
+        Self {
+            cmd: "xpub".to_string(),
+            master,
+            epubkey: epubkey.serialize().to_vec(),
+            xcvc
+        }
+    }
+}
+
+
+// Responses
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct ErrorResponse {
+    pub error: String,
+    pub code: usize,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct StatusResponse {
+    pub proto: usize,
+    pub ver: String,
+    pub birth: usize,
+    pub slots: Option<Vec<usize>>,
+    pub addr: Option<String>,
+    pub tapsigner: Option<bool>,
+    pub satschip: Option<bool>,
+    pub path: Option<Vec<usize>>,
+    pub num_backups: Option<usize>,
+    #[serde(with = "serde_bytes")]
+    pub pubkey: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+    pub testnet: Option<bool>,
+    #[serde(default)]
+    pub auth_delay: Option<usize>,
+}
+
+impl ResponseApdu for StatusResponse {}
+
+// impl std::fmt::Display for StatusResponse {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         write!(f, "Name: {}, Age: {}", self.name, self.age)
+//     }
+// }
+
+/// Read Response
+///
+/// The signature is created from the digest (SHA-256) of these bytes:
+///
+/// b'OPENDIME' (8 bytes)
+/// (card_nonce - 16 bytes)
+/// (nonce from read command - 16 bytes)
+/// (slot - 1 byte)
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ReadResponse {
+    /// signature over a bunch of fields using private key of slot, 64 bytes
+    #[serde(with = "serde_bytes")]
+    pub sig: Vec<u8>,
+    /// public key for this slot/derivation, 33 bytes
+    #[serde(with = "serde_bytes")]
+    pub pubkey: Vec<u8>,
+    /// new nonce value, for NEXT command (not this one), 16 bytes
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+// fn serialize_hex_vec<S>(value: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+// where
+//     S: serde::Serializer,
+// {
+//     let hex_str = value.iter().map(|b| format!("{:02X}", b)).collect::<String>();
+//     serializer.serialize_str(&hex_str)
+// }
+
+impl ResponseApdu for ReadResponse {}
+
+impl fmt::Debug for ReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ReadResponse")
+            .field("sig", &encode(&self.sig))
+            .field("pubkey", &encode(&self.pubkey))
+            .field("card_nonce", &encode(&self.card_nonce))
+            .finish()
+    }
+}
+
+/// nfc Response
+///
+/// URL for smart phone to navigate to
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct NfcResponse {
+    /// command result
+    pub url: String
+}
+
+impl ResponseApdu for NfcResponse {}
+
+/// Sign Response
+///
+// SATSCARD: Arbitrary signatures can be created for unsealed slots. The app could perform this, since the private key is known, but it's best if the app isn't contaminated with private key information. This could be used for both spending and multisig wallet operations.
+//
+// TAPSIGNER: This is its core feature — signing an arbitrary message digest with a tap. Once the card is set up (the key is picked), the command will always be valid.
+#[derive(Deserialize, Clone, PartialEq, Eq)]
+pub struct SignResponse {
+    /// command result
+    pub slot: u8,
+    #[serde(with = "serde_bytes")]
+    pub sig: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub pubkey: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>, 
+}
+
+impl ResponseApdu for SignResponse {}
+
+impl fmt::Debug for SignResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SignResponse")
+            .field("slot", &self.slot)
+            .field("sig", &encode(&self.sig))
+            .field("pubkey", &encode(&self.pubkey))
+            .field("card_nonce", &encode(&self.card_nonce))
+            .finish()
+    }
+}
+
+
+/// Wait Response
+///
+/// When auth_delay is zero, the CVC can be retried and tested without side effects.
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct WaitResponse {
+    /// command result
+    pub success: bool,
+    /// how much more delay is now required
+    #[serde(default)]
+    pub auth_delay: usize,
+}
+
+impl ResponseApdu for WaitResponse {}
+
+/// The response is static for any particular card. The values are captured during factory setup.
+/// Each entry in the list is a 65-byte signature. The first signature signs the card's public key,
+/// and each following signature signs the public key used in the previous signature. Although two
+/// levels of signatures are planned, more are possible.
+#[derive(Deserialize, Clone, Debug)]
+pub struct CertsResponse {
+    /// list of certificates, from 'batch' to 'root'
+    cert_chain: Vec<Value>,
+}
+impl ResponseApdu for CertsResponse {}
+
+impl CertsResponse {
+    pub fn cert_chain(&self) -> Vec<Vec<u8>> {
+        self.clone()
+            .cert_chain
+            .into_iter()
+            .filter_map(|v| match v {
+                Value::Bytes(bv) => Some(bv),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+/// Check Certs Response
+///
+/// The auth_sig value is a signature made using the card's public key (card_pubkey).
+///
+/// The signature is created from the digest (SHA-256) of these bytes:
+///
+/// b'OPENDIME' (8 bytes)
+/// (card_nonce - 16 bytes)
+/// (nonce from check command - 16 bytes)
+///
+/// Starting in version 1.0.0 of the SATSCARD, the public key (33 bytes) for the current slot is appended to the above message. (If the current slot is unsealed or not yet used, this does not happen.) With the pubkey in place, the message being signed will be:
+///
+/// b'OPENDIME' (8 bytes)
+/// (card_nonce - 16 bytes)
+/// (nonce from check command - 16 bytes)
+/// (pubkey of current sealed slot - 33 bytes)
+///
+/// The app verifies this signature and checks that the public key in use is the card_pubkey to prove it is talking to a genuine Coinkite card. The signatures of each certificate chain element are then verified by recovering the pubkey at each step. This checks that the batch certificate is signing the card's pubkey, that the root certificate is signing the batch certificate's key and so on. The root certificate's expected pubkey must be shared out-of-band and already known to the app.
+///
+/// At this time, the only valid factory root pubkey is:
+///
+/// 03028a0e89e70d0ec0d932053a89ab1da7d9182bdc6d2f03e706ee99517d05d9e1
+#[derive(Deserialize, Clone, Debug)]
+pub struct CheckResponse {
+    /// signature using card_pubkey, 64 bytes
+    #[serde(with = "serde_bytes")]
+    auth_sig: Vec<u8>,
+    /// new nonce value, for NEXT command (not this one), 16 bytes
+    #[serde(with = "serde_bytes")]
+    card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for CheckResponse {}
+
+/// New Response
+///
+/// There is a very, very small — 1 in 2128 — chance of arriving at an invalid private key. This
+/// returns error 205 (unlucky number). Retries are allowed with no delay. Also, buy a lottery
+/// ticket immediately.
+///
+/// SATSCARD: derived address is generated based on m/0.
+///
+/// TAPSIGNER: uses the default derivation path of m/84h/0h/0h.
+///
+/// In either case, the status and read commands are required to learn the details of the new
+/// address/key.
+#[derive(Deserialize, Clone, Debug)]
+pub struct NewResponse {
+    /// slot just made
+    slot: usize,
+    /// new nonce value, for NEXT command (not this one), 16 bytes
+    #[serde(with = "serde_bytes")]
+    card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for NewResponse {}
+
+/// Dump Response
+///
+/// Without the CVC, the dump command returns just the sealed/unsealed/unused status for each slot,
+/// with the exception of unsealed slots where the address in full is also provided.
+#[derive(Deserialize, Clone, Debug)]
+pub struct DumpResponse {
+    /// slot just made
+    slot: usize,
+    /// private key for spending (for addr), 32 bytes
+    /// The private keys are encrypted, XORed with the session key
+    #[serde(with = "serde_bytes")]
+    #[serde(default)]
+    privkey: Option<Vec<u8>>,
+    /// public key, 33 bytes
+    #[serde(with = "serde_bytes")]
+    #[serde(default)]
+    pubkey: Vec<u8>,
+    /// nonce provided by customer originally
+    #[serde(with = "serde_bytes")]
+    #[serde(default)]
+    chain_code: Option<Vec<u8>>,
+    /// master private key for this slot (was picked by card), 32 bytes
+    #[serde(with = "serde_bytes")]
+    #[serde(default)]
+    master_pk: Option<Vec<u8>>,
+    /// flag that slots unsealed for unusual reasons (absent if false)
+    #[serde(default)]
+    tampered: Option<bool>,
+    /// if no xcvc provided, slot used status
+    #[serde(default)]
+    used: Option<bool>,
+    /// if no xcvc provided, slot sealed status
+    sealed: Option<bool>,
+    /// if no xcvc provided, full payment address (not censored)
+    #[serde(default)]
+    addr: Option<String>,
+    /// new nonce value, for NEXT command (not this one), 16 bytes
+    #[serde(with = "serde_bytes")]
+    card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for DumpResponse {}
+
+
+#[derive(Deserialize, Clone)]
+pub struct XpubResponse {
+    #[serde(with = "serde_bytes")]
+    pub xpub: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for XpubResponse {}
+
+impl fmt::Debug for XpubResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("XpubResponse")
+            .field("xpub", &encode(&self.xpub))
+            .field("card_nonce", &encode(&self.card_nonce))
+            .finish()
+    }
+}
+
+// Response for a used slot with XCVC provided:
+//
+// {
+//     'slot': 0,                     # which slot is being dumped
+//     'privkey': (32 bytes),         # private key for spending (for addr)
+//     'pubkey': (33 bytes),          # public key
+//     'chain_code': (32 bytes),      # nonce provided by customer originally
+//     'master_pk': (32 bytes),       # master private key for this slot (was picked by card)
+//     'tampered': (bool),            # flag that slots unsealed for unusual reasons (absent if false)
+//     'card_nonce': (16 bytes)       # new nonce value, for NEXT command (not this one)
+// }
+//
+// The private keys are encrypted, XORed with the session key, but the other values are shared unencrypted.
+//
+// The tampered field is only present (and True) if the slot was unsealed due to confusion or uncertainty about its status. In other words, if the card unsealed itself rather than via a successful unseal command.
+//
+// If the XCVC (and/or epubkey) is not provided, then the response contains the full payment address and indicates it is unsealed. In version 1.0.3 and later, the full compressed pubkey for the payment address is also provided.
+//
+// {
+//     'slot': 0,                     # which slot is being dumped
+//     'sealed': False,
+//     'addr': 'bc1qsqkhv..qf735wvl3lh8',   # full payment address (not censored)
+//     'pubkey': (33 bytes),          # public key corresponding to payment address (since v1.0.3)
+//     'card_nonce': (16 bytes)       # new nonce value, for NEXT command (not this one)
+// }
+//
+// The response for an unused slot (no CVC provided):
+//
+// {
+//     'slot': 2,                     # which slot is being dumped
+//     'used': False,
+//     'card_nonce': (16 bytes)       # new nonce value, for NEXT command (not this one)
+// }
+//
+// For the currently active slot, the response is (no CVC provided):
+//
+// {
+//     'slot': 3,                     # which slot is being dumped
+//     'sealed': True,
+//     'card_nonce': (16 bytes)       # new nonce value, for NEXT command (not this one)
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,15 @@
-use ciborium::de::from_reader;
-use ciborium::ser::into_writer;
-use ciborium::value::Value;
-use secp256k1::PublicKey;
-use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
-pub const APP_ID: [u8; 15] = *b"\xf0CoinkiteCARDv1";
+// use ciborium::de::from_reader;
+// use ciborium::value::Value;
 
-pub const SELECT_CLA_INS_P1P2: [u8; 4] = [0x00, 0xA4, 0x04, 0x00];
-pub const CBOR_CLA_INS_P1P2: [u8; 4] = [0x00, 0xCB, 0x00, 0x00];
+use secp256k1::ecdh::SharedSecret;
+use secp256k1::hashes::{sha256, Hash};
+// use secp256k1::rand::rngs::ThreadRng;
+// use secp256k1::rand::Rng;
+use secp256k1::{rand, All, PublicKey, Secp256k1, SecretKey};
 
-// require nonce sizes (bytes)
-pub const CARD_NONCE_SIZE: usize = 16;
-pub const USER_NONCE_SIZE: usize = 16;
+pub mod commands;
+use commands::*;
 
 #[derive(Debug)]
 pub enum CardType {
@@ -20,414 +17,9 @@ pub enum CardType {
     SatsCard
 }
 
-// Errors
-
-#[derive(Debug)]
-pub enum Error {
-    CiborDe(String),
-    CiborValue(String),
-    CkTap {
-        error: String,
-        code: usize,
-    },
-    #[cfg(feature = "pcsc")]
-    PcSc(String),
-}
-
-impl<T> From<ciborium::de::Error<T>> for Error
-where
-    T: core::fmt::Debug,
-{
-    fn from(e: ciborium::de::Error<T>) -> Self {
-        Error::CiborDe(e.to_string())
-    }
-}
-
-impl From<ciborium::value::Error> for Error {
-    fn from(e: ciborium::value::Error) -> Self {
-        Error::CiborDe(e.to_string())
-    }
-}
-
-#[cfg(feature = "pcsc")]
-impl From<pcsc::Error> for Error {
-    fn from(e: pcsc::Error) -> Self {
-        Error::PcSc(e.to_string())
-    }
-}
-
-// Apdu Traits
-
-pub trait CommandApdu {
-    fn apdu_bytes(&self) -> Vec<u8>
-    where
-        Self: serde::Serialize,
-    {
-        let mut command = Vec::new();
-        into_writer(&self, &mut command).unwrap();
-        build_apdu(&CBOR_CLA_INS_P1P2, command.as_slice())
-    }
-}
-
-pub trait ResponseApdu {
-    fn from_cbor<'a>(cbor: Vec<u8>) -> Result<Self, Error>
-    where
-        Self: Deserialize<'a> + Debug,
-    {
-        let cbor_value: Value = from_reader(&cbor[..])?;
-        let cbor_struct: Result<ErrorResponse, _> = cbor_value.deserialized();
-        if let Ok(error_resp) = cbor_struct {
-            Err(Error::CkTap {
-                error: error_resp.error,
-                code: error_resp.code,
-            })?;
-        }
-        let cbor_struct: Self = cbor_value.deserialized()?;
-        Ok(cbor_struct)
-    }
-}
-
-fn build_apdu(header: &[u8], command: &[u8]) -> Vec<u8> {
-    let command_len = command.len();
-    assert!(command_len <= 255, "apdu command too long"); // TODO use Err
-    [header, &[command_len as u8], command].concat()
-}
-
-// Commands
-
-/// Applet Select
-///
-#[derive(Default, Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct AppletSelect {}
-
-impl CommandApdu for AppletSelect {
-    fn apdu_bytes(&self) -> Vec<u8> {
-        build_apdu(&SELECT_CLA_INS_P1P2, &APP_ID)
-    }
-}
-
-/// Status Command
-///
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct StatusCommand {
-    /// 'status' command
-    cmd: String,
-}
-
-impl Default for StatusCommand {
-    fn default() -> Self {
-        StatusCommand {
-            cmd: "status".to_string(),
-        }
-    }
-}
-
-impl CommandApdu for StatusCommand {}
-
-/// Read Command
-///
-/// Apps need to write a CBOR message to read a SATSCARD's current payment address, or a
-/// TAPSIGNER's derived public key.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct ReadCommand {
-    /// 'read' command
-    cmd: String,
-    /// provided by app, cannot be all same byte (& should be random), 16 bytes
-    #[serde(with = "serde_bytes")]
-    nonce: Vec<u8>,
-    /// (TAPSIGNER only) auth is required, 33 bytes
-    #[serde(with = "serde_bytes")]
-    epubkey: Option<Vec<u8>>,
-    /// (TAPSIGNER only) auth is required encrypted CVC value, 6 to 32 bytes
-    #[serde(with = "serde_bytes")]
-    xcvc: Option<Vec<u8>>,
-}
-
-impl ReadCommand {
-    pub fn new(nonce: Vec<u8>, epubkey: Option<PublicKey>, xcvc: Option<Vec<u8>>) -> Self {
-        let epubkey_bytes = epubkey.map(|pk| pk.serialize().to_vec());
-        ReadCommand {
-            cmd: "read".to_string(),
-            nonce,
-            epubkey: epubkey_bytes,
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for ReadCommand {}
-
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct DeriveCommand {
-    cmd: String,
-    /// provided by app, cannot be all same byte (& should be random), 16 bytes
-    #[serde(with = "serde_bytes")]
-    nonce: Vec<u8>,
-}
-
-/// nfc command to return dynamic url for NFC-enabled smart phone
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct NfcCommand {
-    cmd: String,
-}
-
-impl Default for NfcCommand {
-    fn default() -> Self {
-        Self {
-            cmd: "status".to_string(),
-        }
-    }
-}
-
-impl CommandApdu for NfcCommand {}
-
-/// Sign Command
-/// {
-//     'cmd': 'sign',              # command
-//     'slot': 0,                  # (optional) which slot's to key to use, must be unsealed.
-//     'subpath': [0, 0],          # (TAPSIGNER only) additional derivation keypath to be used
-//     'digest': (32 bytes),        # message digest to be signed
-//     'epubkey': (33 bytes),       # app's ephemeral public key
-//     'xcvc': (6 bytes)          # encrypted CVC value
-// }
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct SignCommand {
-    cmd: String,
-    slot: Option<u8>,
-    subpath: Option<[u32; 2]>, // additional keypath for TapSigner only
-    #[serde(with = "serde_bytes")]
-    digest: Vec<u8>, // message digest to be signed
-    #[serde(with = "serde_bytes")]
-    epubkey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    xcvc: Vec<u8>,
-}
-
-impl SignCommand {
-    // pub fn for_satscard(slot: Option<u8>, digest: Vec<u8>, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
-    //     Self {
-    //         cmd: "sign".to_string(),
-    //         slot,
-    //         digest,
-    //         subpath: None,
-    //         epubkey,
-    //         xcvc,
-    //     }
-    // }
-
-    pub fn for_tapsigner(subpath: Option<[u32; 2]>, digest: Vec<u8>, epubkey: PublicKey, xcvc: Vec<u8>) -> Self {
-        SignCommand {
-            cmd: "sign".to_string(),
-            slot: Some(0),
-            subpath,
-            digest,
-            epubkey: epubkey.serialize().to_vec(),
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for SignCommand {}
-
-/// Wait Command
-///
-/// Invalid CVC codes return error 401 (bad auth), through the third incorrect attempt. After the
-/// third incorrect attempt, a 15-second delay is required. Any further attempts to authenticate
-/// will return error 429 (rate limited) until the delay has passed.
-///
-/// In rate-limiting mode, the status command returns the auth_delay field with a positive value.
-///
-/// The wait command takes one second to execute and reduces the auth_delay by one unit. Typically,
-/// 15 wait commands need to be executed before retrying a CVC.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct WaitCommand {
-    /// 'wait' command
-    cmd: String,
-    /// app's ephemeral public key (optional)
-    #[serde(with = "serde_bytes")]
-    epubkey: Option<Vec<u8>>,
-    /// encrypted CVC value (optional), 6 to 32 bytes
-    #[serde(with = "serde_bytes")]
-    xcvc: Option<Vec<u8>>,
-}
-
-impl WaitCommand {
-    pub fn new(epubkey: Option<Vec<u8>>, xcvc: Option<Vec<u8>>) -> Self {
-        WaitCommand {
-            cmd: "wait".to_string(),
-            epubkey,
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for WaitCommand {}
-
-/// Certs Command
-///
-/// This command is used to verify the card was made by Coinkite and is not counterfeit. Two
-/// requests are needed: first, fetch the certificates, and then provide a nonce to be signed.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct CertsCommand {
-    /// 'certs' command
-    cmd: String,
-}
-
-impl Default for CertsCommand {
-    fn default() -> Self {
-        CertsCommand {
-            cmd: "certs".to_string(),
-        }
-    }
-}
-
-impl CommandApdu for CertsCommand {}
-
-/// Check Command
-///
-/// This command is used to verify the card was made by Coinkite and is not counterfeit. Two
-/// requests are needed: first, fetch the certificates, and then provide a nonce to be signed.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct CheckCommand {
-    /// 'check' command
-    cmd: String,
-    /// random value from app, 16 bytes
-    #[serde(with = "serde_bytes")]
-    nonce: Vec<u8>,
-}
-
-impl CheckCommand {
-    pub fn new(nonce: Vec<u8>) -> Self {
-        CheckCommand {
-            cmd: "check".to_string(),
-            nonce,
-        }
-    }
-}
-
-impl CommandApdu for CheckCommand {}
-
-/// New Command
-///
-/// SATSCARD: Use this command to pick a new private key and start a fresh slot. The operation cannot be performed if the current slot is sealed.
-///
-/// TAPSIGNER: This command is only used once.
-///
-/// The slot number is included in the request to prevent command replay.
-///
-/// At this point:
-///
-///     No new slots available? Abort and fail command.
-///     A new key pair is picked and stored into the new slot.
-///         The chain_code must be used in that process and stored.
-///         The card uses TRNG to pick a new master_pubkey (pair).
-///
-/// The new values take effect immediately, so some fields of the next status response will have
-/// new values.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct NewCommand {
-    /// 'new' command
-    cmd: String,
-    /// (optional: default zero) slot to be affected, must equal currently-active slot number
-    slot: usize,
-    /// app's entropy share to be applied to new slot (optional on SATSCARD), 32 bytes
-    #[serde(with = "serde_bytes")]
-    chain_code: Option<Vec<u8>>,
-    /// app's ephemeral public key, 33 bytes
-    #[serde(with = "serde_bytes")]
-    epubkey: Vec<u8>,
-    /// encrypted CVC value, 6 bytes
-    #[serde(with = "serde_bytes")]
-    xcvc: Vec<u8>,
-}
-
-impl NewCommand {
-    pub fn new(slot: usize, chain_code: Option<Vec<u8>>, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
-        NewCommand {
-            cmd: "new".to_string(),
-            slot,
-            chain_code,
-            epubkey,
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for NewCommand {}
-
-/// Dump Command
-///
-/// This reveals the details for any slot. The current slot is not affected. This is a no-op in
-/// terms of response content, if slots aren't available yet, or if a slot hasn't been unsealed.
-/// The factory uses this to verify the CVC is printed correctly without side effects.
-///
-/// If the epubkey or xcvc is absent, the command still works, but the no sensitive information is
-/// shared.
-///
-/// Incorrect auth values for xcvc will fail as normal. Omit the xcvc and epubkey value to proceed
-/// without authentication if CVC is unknown.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct DumpCommand {
-    /// 'dump' command
-    cmd: String,
-    /// which slot to dump, must be unsealed.
-    slot: usize,
-    /// app's ephemeral public key (optional), 33 bytes
-    #[serde(with = "serde_bytes")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    epubkey: Option<Vec<u8>>,
-    /// encrypted CVC value (optional), 6 bytes
-    #[serde(with = "serde_bytes")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    xcvc: Option<Vec<u8>>,
-}
-
-impl DumpCommand {
-    pub fn new(slot: usize, epubkey: Option<Vec<u8>>, xcvc: Option<Vec<u8>>) -> Self {
-        DumpCommand {
-            cmd: "dump".to_string(),
-            slot,
-            epubkey,
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for DumpCommand {}
-
-// Responses
-
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct ErrorResponse {
-    pub error: String,
-    pub code: usize,
-}
-
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct StatusResponse {
-    pub proto: usize,
-    pub ver: String,
-    pub birth: usize,
-    pub slots: Option<Vec<usize>>,
-    pub addr: Option<String>,
-    pub tapsigner: Option<bool>,
-    pub satschip: Option<bool>,
-    pub path: Option<Vec<usize>>,
-    pub num_backups: Option<usize>,
-    #[serde(with = "serde_bytes")]
-    pub pubkey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
-    pub testnet: Option<bool>,
-    #[serde(default)]
-    pub auth_delay: Option<usize>,
-}
-
-impl ResponseApdu for StatusResponse {}
-
-impl StatusResponse {
-    pub fn card_type(&self) -> CardType {
-        if self.addr.is_none() && self.tapsigner.is_some() && self.tapsigner.unwrap() == true {
+impl CardType {
+    pub fn from_status(status: &StatusResponse) -> CardType {
+        if status.addr.is_none() && status.tapsigner.is_some() && status.tapsigner.unwrap() == true {
             CardType::TapSigner
         } else {
             CardType::SatsCard
@@ -435,242 +27,253 @@ impl StatusResponse {
     }
 }
 
-// impl std::fmt::Display for StatusResponse {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         write!(f, "Name: {}, Age: {}", self.name, self.age)
-//     }
-// }
-
-/// Read Response
-///
-/// The signature is created from the digest (SHA-256) of these bytes:
-///
-/// b'OPENDIME' (8 bytes)
-/// (card_nonce - 16 bytes)
-/// (nonce from read command - 16 bytes)
-/// (slot - 1 byte)
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct ReadResponse {
-    /// signature over a bunch of fields using private key of slot, 64 bytes
-    #[serde(with = "serde_bytes")]
-    pub sig: Vec<u8>,
-    /// public key for this slot/derivation, 33 bytes
-    #[serde(with = "serde_bytes")]
-    pub pubkey: Vec<u8>,
-    /// new nonce value, for NEXT command (not this one), 16 bytes
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
+pub trait NfcTransmittor {
+    fn transmit(&self, send_buffer: Vec<u8>) -> Result<Vec<u8>, Error>;
 }
 
-impl ResponseApdu for ReadResponse {}
-
-/// nfc Response
-///
-/// URL for smart phone to navigate to
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct NfcResponse {
-    /// command result
-    pub url: String
+pub struct TapSigner<T: NfcTransmittor> {
+    card: T,
+    pub pubkey: Option<PublicKey>, 
+    pub cvc: Option<String>,
+    secp: Secp256k1<All>, // required here?
+    pub card_nonce: Vec<u8>
 }
 
-impl ResponseApdu for NfcResponse {}
-
-/// Sign Response
-///
-// SATSCARD: Arbitrary signatures can be created for unsealed slots. The app could perform this, since the private key is known, but it's best if the app isn't contaminated with private key information. This could be used for both spending and multisig wallet operations.
-//
-// TAPSIGNER: This is its core feature — signing an arbitrary message digest with a tap. Once the card is set up (the key is picked), the command will always be valid.
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct SignResponse {
-    /// command result
-    pub slot: u8,
-    #[serde(with = "serde_bytes")]
-    pub sig: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub pubkey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>, 
-}
-
-impl ResponseApdu for SignResponse {}
-
-
-/// Wait Response
-///
-/// When auth_delay is zero, the CVC can be retried and tested without side effects.
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct WaitResponse {
-    /// command result
-    pub success: bool,
-    /// how much more delay is now required
-    #[serde(default)]
-    pub auth_delay: usize,
-}
-
-impl ResponseApdu for WaitResponse {}
-
-/// The response is static for any particular card. The values are captured during factory setup.
-/// Each entry in the list is a 65-byte signature. The first signature signs the card's public key,
-/// and each following signature signs the public key used in the previous signature. Although two
-/// levels of signatures are planned, more are possible.
-#[derive(Deserialize, Clone, Debug)]
-pub struct CertsResponse {
-    /// list of certificates, from 'batch' to 'root'
-    cert_chain: Vec<Value>,
-}
-impl ResponseApdu for CertsResponse {}
-
-impl CertsResponse {
-    pub fn cert_chain(&self) -> Vec<Vec<u8>> {
-        self.clone()
-            .cert_chain
-            .into_iter()
-            .filter_map(|v| match v {
-                Value::Bytes(bv) => Some(bv),
-                _ => None,
-            })
-            .collect()
+impl<T: NfcTransmittor> TapSigner<T> {
+    pub fn new(card: T, status: &StatusResponse) -> Self {
+        // let rng = &mut rand::thread_rng();
+        // let nonce = rand_nonce(rng).to_vec();
+        let card_nonce = &status.card_nonce;
+        let secp: Secp256k1<All> = Secp256k1::new();
+        let pubkey = if status.pubkey.len() == 33 {
+            let as_bytes = status.pubkey.as_slice();
+            Some(PublicKey::from_slice(as_bytes).unwrap()) 
+        } else {
+            None
+        };
+        Self { 
+            card, 
+            cvc: None, 
+            card_nonce: card_nonce.to_vec(), 
+            secp, 
+            pubkey 
+        }
     }
+
+    pub fn set_cvc(&mut self, cvc: String) {
+        self.cvc = Some(cvc);
+    }
+
+    fn xcvc(&self, command: &String) -> (SecretKey, PublicKey, Vec<u8>) {
+        let cvc_bytes = match &self.cvc {
+            Some(cvc) => cvc.as_bytes(),
+            None => panic!("calc_xcvc requires cvc"),
+        };
+        let pubkey = match &self.pubkey {
+            Some(pk) => pk,
+            None => panic!("calc_xcvc requires a pubkey"),
+        };
+        let card_nonce_bytes = self.card_nonce.as_slice();
+        let card_nonce_command = [card_nonce_bytes, command.as_bytes()].concat();
+
+        let (eseckey, epubkey) = self.secp.generate_keypair(&mut rand::thread_rng());
+        let session_key = SharedSecret::new(&pubkey, &eseckey);
+        
+        let md = sha256::Hash::hash(card_nonce_command.as_slice());
+
+        let mask: Vec<u8> = session_key
+            .as_ref()
+            .iter()
+            .zip(md.as_ref())
+            .map(|(x, y)| x ^ y)
+            .take(cvc_bytes.len())
+            .collect();
+        let xcvc = cvc_bytes.iter().zip(mask).map(|(x, y)| x ^ y).collect();
+        (eseckey, epubkey, xcvc)
+        
+    }
+
+    pub fn read(&mut self) -> Result<ReadResponse, Error> {
+        let (_eseckey, epubkey, xcvc) = self.xcvc(&"read".to_string());
+        let read_cmd = ReadCommand::for_tapsigner(self.card_nonce.clone(), epubkey, xcvc);
+        let read_response = self.transmit_read(read_cmd);
+        match read_response {
+            Ok(resp) => {
+                self.card_nonce = resp.card_nonce.clone();
+                Ok(resp)
+            },
+            Err(error) => panic!("Failed to read card: {:?}", error),
+        }
+    }
+
+    pub fn sign(&mut self, digest: Vec<u8>, subpath: Option<[u32; 2]>) -> Result<SignResponse, Error> {
+        let (_eseckey, epubkey, xcvc) = self.xcvc(&"sign".to_string());
+        let command = SignCommand::for_tapsigner(subpath, digest, epubkey, xcvc);
+        let sign_response = self.transmit_sign(command);    
+        match sign_response {
+            Ok(resp) => {
+                self.card_nonce = resp.card_nonce.clone();
+                Ok(resp)
+            },
+            Err(error) => panic!("Failed to read card: {:?}", error),
+        }
+    }
+
+    pub fn xpub(&mut self, master: bool) -> Result<XpubResponse, Error>  {
+        let (_eseckey, epubkey, xcvc) = self.xcvc(&"xpub".to_string());
+        let command = XpubCommand::new(master, epubkey, xcvc);
+        let xpub_response = self.transmit_xpub(command);    
+        match xpub_response {
+            Ok(resp) => {
+                self.card_nonce = resp.card_nonce.clone();
+                Ok(resp)
+            },
+            Err(error) => panic!("Failed to read card: {:?}", error),
+        }
+    }
+
+    // TODO - generalize transmit. can be abstracted to trait for each 
+    fn transmit_read(&self, cmd: ReadCommand) -> Result<ReadResponse, Error> {
+        let read_apdu = cmd.apdu_bytes();
+        let rapdu = self.card.transmit(read_apdu)?;
+        Ok(ReadResponse::from_cbor(rapdu.to_vec())?)
+    }
+
+    // TODO - generalize transmit. can be abstracted to trait for each 
+    fn transmit_sign(&self, cmd: SignCommand) -> Result<SignResponse, Error> {
+        let req_apdu = cmd.apdu_bytes();
+        let resp_apdu = self.card.transmit(req_apdu)?;
+        Ok(SignResponse::from_cbor(resp_apdu.to_vec())?)
+    }
+
+    fn transmit_xpub(&self, cmd: XpubCommand) -> Result<XpubResponse, Error> {
+        let req_apdu = cmd.apdu_bytes();
+        let resp_apdu = self.card.transmit(req_apdu)?;
+        Ok(XpubResponse::from_cbor(resp_apdu.to_vec())?)
+    }
+
+    // -> Requires dynamic dispatch at for return value?
+    // fn transmit<T: Serialize, U: Deserialize>(&self, cmd: T) -> Result<U, Error> {
+    //     let req_apdu = cmd.apdu_bytes();
+    //     let resp_apdu = self.card.transmit(req_apdu)?;
+    //     Ok(U::from_cbor(resp_apdu.to_vec())?)
+    // }
 }
 
-/// Check Certs Response
-///
-/// The auth_sig value is a signature made using the card's public key (card_pubkey).
-///
-/// The signature is created from the digest (SHA-256) of these bytes:
-///
-/// b'OPENDIME' (8 bytes)
-/// (card_nonce - 16 bytes)
-/// (nonce from check command - 16 bytes)
-///
-/// Starting in version 1.0.0 of the SATSCARD, the public key (33 bytes) for the current slot is appended to the above message. (If the current slot is unsealed or not yet used, this does not happen.) With the pubkey in place, the message being signed will be:
-///
-/// b'OPENDIME' (8 bytes)
-/// (card_nonce - 16 bytes)
-/// (nonce from check command - 16 bytes)
-/// (pubkey of current sealed slot - 33 bytes)
-///
-/// The app verifies this signature and checks that the public key in use is the card_pubkey to prove it is talking to a genuine Coinkite card. The signatures of each certificate chain element are then verified by recovering the pubkey at each step. This checks that the batch certificate is signing the card's pubkey, that the root certificate is signing the batch certificate's key and so on. The root certificate's expected pubkey must be shared out-of-band and already known to the app.
-///
-/// At this time, the only valid factory root pubkey is:
-///
-/// 03028a0e89e70d0ec0d932053a89ab1da7d9182bdc6d2f03e706ee99517d05d9e1
-#[derive(Deserialize, Clone, Debug)]
-pub struct CheckResponse {
-    /// signature using card_pubkey, 64 bytes
-    #[serde(with = "serde_bytes")]
-    auth_sig: Vec<u8>,
-    /// new nonce value, for NEXT command (not this one), 16 bytes
-    #[serde(with = "serde_bytes")]
-    card_nonce: Vec<u8>,
+pub fn applet_select<T: NfcTransmittor>(card: &T) -> Result<StatusResponse, Error> {
+    let applet_select_apdu = AppletSelect::default().apdu_bytes();
+    let rapdu = card.transmit(applet_select_apdu)?;
+    let status_response = StatusResponse::from_cbor(rapdu.to_vec())?;
+    Ok(status_response)
 }
 
-impl ResponseApdu for CheckResponse {}
+// fn status_command(card: &Card) -> Result<StatusResponse, Error> {
+//     // Send 'status' command.
+//     let status_apdu = StatusCommand::default().apdu_bytes();
+//     println!("Sending 'status' APDU: {:?}\n", &status_apdu);
+//     let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
+//     let rapdu = card.transmit(&status_apdu.as_slice(), &mut rapdu_buf)?;
+//     let status_response = StatusResponse::from_cbor(rapdu.to_vec())?;
+//     println!("Received 'Status' APDU: {:?}\n", &status_response);
+//     Ok(status_response)
+// }
 
-/// New Response
-///
-/// There is a very, very small — 1 in 2128 — chance of arriving at an invalid private key. This
-/// returns error 205 (unlucky number). Retries are allowed with no delay. Also, buy a lottery
-/// ticket immediately.
-///
-/// SATSCARD: derived address is generated based on m/0.
-///
-/// TAPSIGNER: uses the default derivation path of m/84h/0h/0h.
-///
-/// In either case, the status and read commands are required to learn the details of the new
-/// address/key.
-#[derive(Deserialize, Clone, Debug)]
-pub struct NewResponse {
-    /// slot just made
-    slot: usize,
-    /// new nonce value, for NEXT command (not this one), 16 bytes
-    #[serde(with = "serde_bytes")]
-    card_nonce: Vec<u8>,
+// fn certs_command(card: &Card) -> Result<CertsResponse, Error> {
+//     // Send 'certs' command.
+//     let certs_apdu = CertsCommand::default().apdu_bytes();
+//     println!("Sending 'certs' APDU: {:?}\n", &certs_apdu);
+//     let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
+//     let rapdu = card.transmit(&certs_apdu.as_slice(), &mut rapdu_buf)?;
+//     let certs_response = CertsResponse::from_cbor(rapdu.to_vec())?;
+//     println!("Received 'Certs' APDU: {:?}\n", &certs_response);
+//     println!(
+//         "Received 'Certs' cert_chain: {:?}\n",
+//         &certs_response.cert_chain()
+//     );
+//     Ok(certs_response)
+// }
+
+// fn check_command(card: &Card, nonce: Vec<u8>) -> Result<CheckResponse, Error> {
+//     // Send 'check' command.
+//     let check_apdu = CheckCommand::new(nonce).apdu_bytes();
+//     println!("Sending 'check' APDU: {:?}\n", &check_apdu);
+//     let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
+    // let rapdu = card.transmit(&check_apdu.as_slice(), &mut rapdu_buf)?;
+//     let check_response = CheckResponse::from_cbor(rapdu.to_vec())?;
+//     println!("Received 'Check' APDU: {:?}\n", &check_response);
+//     Ok(check_response)
+// }
+
+
+// TODO - move to satscard struct
+pub fn read_command<T: NfcTransmittor>(
+    card: &T,
+    card_nonce: Vec<u8>
+) -> Result<ReadResponse, Error> {
+    // Send 'read' command.
+    let read_struct = ReadCommand::for_satscard(card_nonce);
+    let read_apdu = read_struct.apdu_bytes();
+    let rapdu = card.transmit(read_apdu)?;
+    let read_response = ReadResponse::from_cbor(rapdu.to_vec())?;
+    Ok(read_response)
 }
 
-impl ResponseApdu for NewResponse {}
+// fn sign_command<T: NfcTransmittor>(
+//     card: &T,
+//     digest: Vec<u8>,
+//     epubkey: PublicKey,
+//     xcvc: Vec<u8>,
+// ) -> Result<SignResponse, Error> {
+//     let command = SignCommand::for_tapsigner(Some([0,0]), digest, epubkey, xcvc);
+//     println!("Sending SignCommand: {:?}\n", &command);
+//     let req_apdu = command.apdu_bytes();
+//     println!("Request APDU: {:?}\n", &req_apdu);
+//     let resp_apdu = card.transmit(req_apdu)?;
+//     let sign_response = SignResponse::from_cbor(resp_apdu.to_vec())?;
+//     Ok(sign_response)
+// }
 
-/// Dump Response
-///
-/// Without the CVC, the dump command returns just the sealed/unsealed/unused status for each slot,
-/// with the exception of unsealed slots where the address in full is also provided.
-#[derive(Deserialize, Clone, Debug)]
-pub struct DumpResponse {
-    /// slot just made
-    slot: usize,
-    /// private key for spending (for addr), 32 bytes
-    /// The private keys are encrypted, XORed with the session key
-    #[serde(with = "serde_bytes")]
-    #[serde(default)]
-    privkey: Option<Vec<u8>>,
-    /// public key, 33 bytes
-    #[serde(with = "serde_bytes")]
-    #[serde(default)]
-    pubkey: Vec<u8>,
-    /// nonce provided by customer originally
-    #[serde(with = "serde_bytes")]
-    #[serde(default)]
-    chain_code: Option<Vec<u8>>,
-    /// master private key for this slot (was picked by card), 32 bytes
-    #[serde(with = "serde_bytes")]
-    #[serde(default)]
-    master_pk: Option<Vec<u8>>,
-    /// flag that slots unsealed for unusual reasons (absent if false)
-    #[serde(default)]
-    tampered: Option<bool>,
-    /// if no xcvc provided, slot used status
-    #[serde(default)]
-    used: Option<bool>,
-    /// if no xcvc provided, slot sealed status
-    sealed: Option<bool>,
-    /// if no xcvc provided, full payment address (not censored)
-    #[serde(default)]
-    addr: Option<String>,
-    /// new nonce value, for NEXT command (not this one), 16 bytes
-    #[serde(with = "serde_bytes")]
-    card_nonce: Vec<u8>,
+// fn new_command(
+//     card: &Card,
+//     slot: usize,
+//     chain_code: Option<Vec<u8>>,
+//     epubkey: Vec<u8>,
+//     xcvc: Vec<u8>,
+// ) -> Result<NewResponse, Error> {
+//     // Send 'new' command.
+//     let new_apdu = NewCommand::new(slot, chain_code, epubkey, xcvc).apdu_bytes();
+//     println!("Sending 'new' APDU: {:?}\n", &new_apdu);
+//     let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
+//     let rapdu = card.transmit(&new_apdu.as_slice(), &mut rapdu_buf)?;
+//     let new_response = NewResponse::from_cbor(rapdu.to_vec())?;
+//     println!("Received 'New' APDU: {:?}\n", &new_response);
+//     Ok(new_response)
+// }
+
+pub fn wait_command<T: NfcTransmittor>(card: &T, xcvc: Option<Vec<u8>>) -> Result<WaitResponse, Error> {
+    // Send 'wait' command.
+    let wait_apdu = WaitCommand::new(None, xcvc).apdu_bytes();
+    println!("Sending 'Wait' APDU: {:?}\n", &wait_apdu);
+    let rapdu = card.transmit(wait_apdu)?;
+    let wait_response = WaitResponse::from_cbor(rapdu.to_vec())?;
+    println!("Received 'Wait' APDU: {:?}\n", &wait_response);
+    Ok(wait_response)
 }
 
-impl ResponseApdu for DumpResponse {}
+// fn dump_command(
+//     card: &Card,
+//     slot: usize,
+//     epubkey: Option<Vec<u8>>,
+//     xcvc: Option<Vec<u8>>,
+// ) -> Result<DumpResponse, Error> {
+//     // Send 'dump' command
+//     let dump_apdu = DumpCommand::new(slot, epubkey, xcvc).apdu_bytes();
+//     println!("Sending 'dump' APDU: {:?}\n", &dump_apdu);
+//     let mut rapdu_buf = [0; MAX_BUFFER_SIZE];
+//     let rapdu = card.transmit(&dump_apdu.as_slice(), &mut rapdu_buf)?;
+//     let cbor_response: Value = from_reader(rapdu)?;
+//     let dump_response = DumpResponse::from_cbor(rapdu.to_vec())?;
+//     println!("Received 'dump' APDU: {:?}\n", &dump_response);
+//     Ok(dump_response)
+// }
 
-// Response for a used slot with XCVC provided:
-//
-// {
-//     'slot': 0,                     # which slot is being dumped
-//     'privkey': (32 bytes),         # private key for spending (for addr)
-//     'pubkey': (33 bytes),          # public key
-//     'chain_code': (32 bytes),      # nonce provided by customer originally
-//     'master_pk': (32 bytes),       # master private key for this slot (was picked by card)
-//     'tampered': (bool),            # flag that slots unsealed for unusual reasons (absent if false)
-//     'card_nonce': (16 bytes)       # new nonce value, for NEXT command (not this one)
-// }
-//
-// The private keys are encrypted, XORed with the session key, but the other values are shared unencrypted.
-//
-// The tampered field is only present (and True) if the slot was unsealed due to confusion or uncertainty about its status. In other words, if the card unsealed itself rather than via a successful unseal command.
-//
-// If the XCVC (and/or epubkey) is not provided, then the response contains the full payment address and indicates it is unsealed. In version 1.0.3 and later, the full compressed pubkey for the payment address is also provided.
-//
-// {
-//     'slot': 0,                     # which slot is being dumped
-//     'sealed': False,
-//     'addr': 'bc1qsqkhv..qf735wvl3lh8',   # full payment address (not censored)
-//     'pubkey': (33 bytes),          # public key corresponding to payment address (since v1.0.3)
-//     'card_nonce': (16 bytes)       # new nonce value, for NEXT command (not this one)
-// }
-//
-// The response for an unused slot (no CVC provided):
-//
-// {
-//     'slot': 2,                     # which slot is being dumped
-//     'used': False,
-//     'card_nonce': (16 bytes)       # new nonce value, for NEXT command (not this one)
-// }
-//
-// For the currently active slot, the response is (no CVC provided):
-//
-// {
-//     'slot': 3,                     # which slot is being dumped
-//     'sealed': True,
-//     'card_nonce': (16 bytes)       # new nonce value, for NEXT command (not this one)
-// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,12 @@ pub const CBOR_CLA_INS_P1P2: [u8; 4] = [0x00, 0xCB, 0x00, 0x00];
 pub const CARD_NONCE_SIZE: usize = 16;
 pub const USER_NONCE_SIZE: usize = 16;
 
+#[derive(Debug)]
+pub enum CardType {
+    TapSigner,
+    SatsCard
+}
+
 // Errors
 
 #[derive(Debug)]
@@ -150,6 +156,14 @@ impl ReadCommand {
 }
 
 impl CommandApdu for ReadCommand {}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct DeriveCommand {
+    cmd: String,
+    /// provided by app, cannot be all same byte (& should be random), 16 bytes
+    #[serde(with = "serde_bytes")]
+    nonce: Vec<u8>,
+}
 
 /// Wait Command
 ///
@@ -346,6 +360,24 @@ pub struct StatusResponse {
 }
 
 impl ResponseApdu for StatusResponse {}
+
+impl StatusResponse {
+    pub fn card_type(&self) -> CardType {
+        if self.addr.is_none()
+        && self.tapsigner.is_some()
+        && self.tapsigner.unwrap() == true {
+            CardType::TapSigner
+        } else {
+            CardType::SatsCard
+        }
+    }
+}
+
+// impl std::fmt::Display for StatusResponse {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         write!(f, "Name: {}, Age: {}", self.name, self.age)
+//     }
+// }
 
 /// Read Response
 ///


### PR DESCRIPTION
lib.rs contains interfaces for TapSigner and SatsCard along with a NfcTransmitter (Transport?) trait.

example/pcsc.rs contains a CardReader with an implementation of the trait NfcTransmitter (rename to PcscTransport and Transport?) 

commands.rs contains the structs to be sent via the tap protocol as defined by the spec