### PR TITLE
Refactor: Commands as traits + new Card construction

### DIFF
--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -1,0 +1,853 @@
+/// An Application Protocol Data Unit (APDU) is the unit of communication between a smart card
+/// reader and a smart card. This file defines the Coinkite APDU and set of command/responses.
+use ciborium::de::from_reader;
+use ciborium::ser::into_writer;
+use ciborium::value::Value;
+use secp256k1::hashes::hex::ToHex;
+use secp256k1::PublicKey;
+use serde;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
+pub const APP_ID: [u8; 15] = *b"\xf0CoinkiteCARDv1";
+pub const SELECT_CLA_INS_P1P2: [u8; 4] = [0x00, 0xA4, 0x04, 0x00];
+pub const CBOR_CLA_INS_P1P2: [u8; 4] = [0x00, 0xCB, 0x00, 0x00];
+
+// require nonce sizes (bytes)
+pub const CARD_NONCE_SIZE: usize = 16;
+pub const USER_NONCE_SIZE: usize = 16;
+
+// Errors
+#[derive(Debug)]
+pub enum Error {
+    CiborDe(String),
+    CiborValue(String),
+    CkTap {
+        error: String,
+        code: usize,
+    },
+    IncorrectSignature(String),
+    UnknownCardType(String),
+    #[cfg(feature = "pcsc")]
+    PcSc(String),
+}
+
+impl<T> From<ciborium::de::Error<T>> for Error
+where
+    T: Debug,
+{
+    fn from(e: ciborium::de::Error<T>) -> Self {
+        Error::CiborDe(e.to_string())
+    }
+}
+
+impl From<ciborium::value::Error> for Error {
+    fn from(e: ciborium::value::Error) -> Self {
+        Error::CiborValue(e.to_string())
+    }
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(e: secp256k1::Error) -> Self {
+        Error::IncorrectSignature(e.to_string())
+    }
+}
+
+#[cfg(feature = "pcsc")]
+impl From<pcsc::Error> for Error {
+    fn from(e: pcsc::Error) -> Self {
+        Error::PcSc(e.to_string())
+    }
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct ErrorResponse {
+    pub error: String,
+    pub code: usize,
+}
+
+// Apdu Traits
+pub trait CommandApdu {
+    fn name() -> String;
+    fn apdu_bytes(&self) -> Vec<u8>
+    where
+        Self: serde::Serialize + Debug,
+    {
+        let mut command = Vec::new();
+        into_writer(&self, &mut command).unwrap();
+        build_apdu(&CBOR_CLA_INS_P1P2, command.as_slice())
+    }
+}
+
+pub trait ResponseApdu {
+    fn from_cbor<'a>(cbor: Vec<u8>) -> Result<Self, Error>
+    where
+        Self: Deserialize<'a> + Debug,
+    {
+        let cbor_value: Value = from_reader(&cbor[..])?;
+        let cbor_struct: Result<ErrorResponse, _> = cbor_value.deserialized();
+        if let Ok(error_resp) = cbor_struct {
+            return Err(Error::CkTap {
+                error: error_resp.error,
+                code: error_resp.code,
+            });
+        }
+        let cbor_struct: Self = cbor_value.deserialized()?;
+        Ok(cbor_struct)
+    }
+}
+
+fn build_apdu(header: &[u8], command: &[u8]) -> Vec<u8> {
+    let command_len = command.len();
+    assert!(command_len <= 255, "apdu command too long"); // TODO use Err
+    [header, &[command_len as u8], command].concat()
+}
+
+/// Applet Select
+#[derive(Default, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct AppletSelect {}
+
+impl CommandApdu for AppletSelect {
+    fn name() -> String {
+        String::default()
+    }
+    fn apdu_bytes(&self) -> Vec<u8> {
+        build_apdu(&SELECT_CLA_INS_P1P2, &APP_ID)
+    }
+}
+
+/// Status Command
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct StatusCommand {
+    /// 'status' command
+    cmd: String,
+}
+
+impl Default for StatusCommand {
+    fn default() -> Self {
+        StatusCommand { cmd: Self::name() }
+    }
+}
+
+impl CommandApdu for StatusCommand {
+    fn name() -> String {
+        "status".to_string()
+    }
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct StatusResponse {
+    pub proto: usize,
+    pub ver: String,
+    pub birth: usize,
+    pub slots: Option<(usize, usize)>,
+    pub addr: Option<String>,
+    pub tapsigner: Option<bool>,
+    pub satschip: Option<bool>,
+    pub path: Option<Vec<usize>>,
+    pub num_backups: Option<usize>,
+    #[serde(with = "serde_bytes")]
+    pub pubkey: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+    pub testnet: Option<bool>,
+    #[serde(default)]
+    pub auth_delay: Option<usize>,
+}
+
+impl ResponseApdu for StatusResponse {}
+
+/// Read Command
+///
+/// Apps need to write a CBOR message to read a SATSCARD's current payment address, or a
+/// TAPSIGNER's derived public key.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct ReadCommand {
+    /// 'read' command
+    cmd: String,
+    /// provided by app, cannot be all same byte (& should be random), 16 bytes
+    #[serde(with = "serde_bytes")]
+    nonce: Vec<u8>,
+    /// (TAPSIGNER only) auth is required, 33 bytes
+    #[serde(with = "serde_bytes")]
+    epubkey: Option<Vec<u8>>,
+    /// (TAPSIGNER only) auth is required encrypted CVC value, 6 to 32 bytes
+    #[serde(with = "serde_bytes")]
+    xcvc: Option<Vec<u8>>,
+}
+
+impl ReadCommand {
+    pub fn authenticated(nonce: Vec<u8>, epubkey: PublicKey, xcvc: Vec<u8>) -> Self {
+        ReadCommand {
+            cmd: Self::name(),
+            nonce,
+            epubkey: Some(epubkey.serialize().to_vec()),
+            xcvc: Some(xcvc),
+        }
+    }
+
+    pub fn unauthenticated(nonce: Vec<u8>) -> Self {
+        ReadCommand {
+            cmd: Self::name(),
+            nonce,
+            epubkey: None,
+            xcvc: None,
+        }
+    }
+}
+
+impl CommandApdu for ReadCommand {
+    fn name() -> String {
+        "read".to_string()
+    }
+}
+
+/// Read Response
+///
+/// The signature is created from the digest (SHA-256) of these bytes:
+///
+/// b'OPENDIME' (8 bytes)
+/// (card_nonce - 16 bytes)
+/// (nonce from read command - 16 bytes)
+/// (slot - 1 byte)
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ReadResponse {
+    /// signature over a bunch of fields using private key of slot, 64 bytes
+    #[serde(with = "serde_bytes")]
+    pub sig: Vec<u8>,
+    /// public key for this slot/derivation, 33 bytes
+    #[serde(with = "serde_bytes")]
+    pub pubkey: Vec<u8>,
+    /// new nonce value, for NEXT command (not this one), 16 bytes
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for ReadResponse {}
+
+impl Debug for ReadResponse {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("ReadResponse")
+            .field("sig", &self.sig.to_hex())
+            .field("pubkey", &self.pubkey.to_hex())
+            .field("card_nonce", &self.card_nonce.to_hex())
+            .finish()
+    }
+}
+
+// impl ReadResponse {
+//     pub fn pubkey(&self) -> PublicKey {
+//         PublicKey::from_slice(self.pubkey.as_slice()).unwrap()
+//     }
+// }
+
+// Checks payment address derivation: https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#satscard-checks-payment-address-derivation
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct DeriveCommand {
+    cmd: String,
+    /// provided by app, cannot be all same byte (& should be random), 16 bytes
+    #[serde(with = "serde_bytes")]
+    nonce: Vec<u8>,
+    path: Option<Vec<usize>>,
+    #[serde(with = "serde_bytes")]
+    epubkey: Option<Vec<u8>>,
+    #[serde(with = "serde_bytes")]
+    xcvc: Option<Vec<u8>>,
+}
+
+impl CommandApdu for DeriveCommand {
+    fn name() -> String {
+        "derive".to_string()
+    }
+}
+
+impl DeriveCommand {
+    pub fn for_satscard(nonce: Vec<u8>) -> Self {
+        DeriveCommand {
+            cmd: Self::name(),
+            nonce,
+            path: None,
+            epubkey: None,
+            xcvc: None,
+        }
+    }
+
+    pub fn for_tapsigner(
+        nonce: Vec<u8>,
+        path: Vec<usize>,
+        epubkey: PublicKey,
+        xcvc: Vec<u8>,
+    ) -> Self {
+        DeriveCommand {
+            cmd: Self::name(),
+            nonce,
+            path: Some(path),
+            epubkey: Some(epubkey.serialize().to_vec()),
+            xcvc: Some(xcvc),
+        }
+    }
+}
+
+#[derive(Deserialize, Clone)]
+pub struct DeriveResponse {
+    #[serde(with = "serde_bytes")]
+    pub sig: Vec<u8>, // 64 byes
+    #[serde(with = "serde_bytes")]
+    pub chain_code: Vec<u8>, // 32 bytes
+    #[serde(with = "serde_bytes")]
+    pub master_pubkey: Vec<u8>, // 33 bytes
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>, // 16 bytes
+}
+
+impl ResponseApdu for DeriveResponse {}
+
+impl Debug for DeriveResponse {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("DeriveResponse")
+            .field("sig", &self.sig.to_hex())
+            .field("chain_code", &self.chain_code.to_hex())
+            .field("master_pubkey", &self.master_pubkey.to_hex())
+            .field("card_nonce", &self.card_nonce.to_hex())
+            .finish()
+    }
+}
+
+/// Certs Command
+///
+/// This command is used to verify the card was made by Coinkite and is not counterfeit. Two
+/// requests are needed: first, fetch the certificates, and then provide a nonce to be signed.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct CertsCommand {
+    /// 'certs' command
+    cmd: String,
+}
+
+impl CommandApdu for CertsCommand {
+    fn name() -> String {
+        "certs".to_string()
+    }
+}
+
+impl Default for CertsCommand {
+    fn default() -> Self {
+        CertsCommand { cmd: Self::name() }
+    }
+}
+
+/// The response is static for any particular card. The values are captured during factory setup.
+/// Each entry in the list is a 65-byte signature. The first signature signs the card's public key,
+/// and each following signature signs the public key used in the previous signature. Although two
+/// levels of signatures are planned, more are possible.
+#[derive(Deserialize, Clone)]
+pub struct CertsResponse {
+    /// list of certificates, from 'batch' to 'root'
+    // TODO create custom deserializer like "serde_bytes" but for Vec<Vec<u8>>
+    cert_chain: Vec<Value>,
+}
+
+impl ResponseApdu for CertsResponse {}
+
+impl CertsResponse {
+    pub fn cert_chain(&self) -> Vec<Vec<u8>> {
+        self.clone()
+            .cert_chain
+            .into_iter()
+            .filter_map(|v| match v {
+                Value::Bytes(bv) => Some(bv),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+impl Debug for CertsResponse {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let cert_hexes: Vec<String> = self.cert_chain().iter().map(|key| key.to_hex()).collect();
+        f.debug_struct("CertsResponse")
+            .field("cert_chain", &cert_hexes)
+            .finish()
+    }
+}
+
+/// Check Command
+///
+/// This command is used to verify the card was made by Coinkite and is not counterfeit. Two
+/// requests are needed: first, fetch the certificates (i.e CertsCommand), and then provide a nonce to be signed.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct CheckCommand {
+    /// 'check' command
+    cmd: String,
+    /// random value from app, 16 bytes
+    #[serde(with = "serde_bytes")]
+    nonce: Vec<u8>,
+}
+
+impl CommandApdu for CheckCommand {
+    fn name() -> String {
+        "check".to_string()
+    }
+}
+
+impl CheckCommand {
+    pub fn new(nonce: Vec<u8>) -> Self {
+        CheckCommand {
+            cmd: Self::name(),
+            nonce,
+        }
+    }
+}
+
+/// Check Certs Response
+/// ref: https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#certs
+#[derive(Deserialize, Clone)]
+pub struct CheckResponse {
+    /// signature using card_pubkey, 64 bytes
+    #[serde(with = "serde_bytes")]
+    pub auth_sig: Vec<u8>,
+    /// new nonce value, for NEXT command (not this one), 16 bytes
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for CheckResponse {}
+
+impl Debug for CheckResponse {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("CheckResponse")
+            .field("auth_sig", &self.auth_sig.to_hex())
+            .field("card_nonce", &self.card_nonce.to_hex())
+            .finish()
+    }
+}
+
+/// nfc command to return dynamic url for NFC-enabled smart phone
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct NfcCommand {
+    cmd: String,
+}
+
+impl Default for NfcCommand {
+    fn default() -> Self {
+        Self { cmd: Self::name() }
+    }
+}
+
+impl CommandApdu for NfcCommand {
+    fn name() -> String {
+        "nfc".to_string()
+    }
+}
+
+/// nfc Response
+///
+/// URL for smart phone to navigate to
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct NfcResponse {
+    /// command result
+    pub url: String,
+}
+
+impl ResponseApdu for NfcResponse {}
+
+/// Sign Command
+// {
+//     'cmd': 'sign',              # command
+//     'slot': 0,                  # (optional) which slot's to key to use, must be unsealed.
+//     'subpath': [0, 0],          # (TAPSIGNER only) additional derivation keypath to be used
+//     'digest': (32 bytes),        # message digest to be signed
+//     'epubkey': (33 bytes),       # app's ephemeral public key
+//     'xcvc': (6 bytes)          # encrypted CVC value
+// }
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct SignCommand {
+    cmd: String,
+    slot: Option<u8>,
+    subpath: Option<[u32; 2]>,
+    // additional keypath for TapSigner only
+    #[serde(with = "serde_bytes")]
+    digest: Vec<u8>,
+    // message digest to be signed
+    #[serde(with = "serde_bytes")]
+    epubkey: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    xcvc: Vec<u8>,
+}
+
+impl SignCommand {
+    // pub fn for_satscard(slot: Option<u8>, digest: Vec<u8>, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
+    //     Self {
+    //         cmd: "sign".to_string(),
+    //         slot,
+    //         digest,
+    //         subpath: None,
+    //         epubkey,
+    //         xcvc,
+    //     }
+    // }
+
+    pub fn for_tapsigner(
+        subpath: Option<[u32; 2]>,
+        digest: Vec<u8>,
+        epubkey: PublicKey,
+        xcvc: Vec<u8>,
+    ) -> Self {
+        let cmd = Self::name();
+
+        SignCommand {
+            cmd,
+            slot: Some(0),
+            subpath,
+            digest,
+            epubkey: epubkey.serialize().to_vec(),
+            xcvc,
+        }
+    }
+}
+
+impl CommandApdu for SignCommand {
+    fn name() -> String {
+        "sign".to_string()
+    }
+}
+
+/// Sign Response
+// SATSCARD: Arbitrary signatures can be created for unsealed slots. The app could perform this, since the private key is known, but it's best if the app isn't contaminated with private key information. This could be used for both spending and multisig wallet operations.
+//
+// TAPSIGNER: This is its core feature — signing an arbitrary message digest with a tap. Once the card is set up (the key is picked), the command will always be valid.
+#[derive(Deserialize, Clone, PartialEq, Eq)]
+pub struct SignResponse {
+    /// command result
+    pub slot: u8,
+    #[serde(with = "serde_bytes")]
+    pub sig: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub pubkey: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for SignResponse {}
+
+impl Debug for SignResponse {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("SignResponse")
+            .field("slot", &self.slot)
+            .field("sig", &self.sig.to_hex())
+            .field("pubkey", &self.pubkey.to_hex())
+            .field("card_nonce", &self.card_nonce.to_hex())
+            .finish()
+    }
+}
+
+/// Wait Command
+///
+/// Invalid CVC codes return error 401 (bad auth), through the third incorrect attempt. After the
+/// third incorrect attempt, a 15-second delay is required. Any further attempts to authenticate
+/// will return error 429 (rate limited) until the delay has passed.
+///
+/// In rate-limiting mode, the status command returns the auth_delay field with a positive value.
+///
+/// The wait command takes one second to execute and reduces the auth_delay by one unit. Typically,
+/// 15 wait commands need to be executed before retrying a CVC.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct WaitCommand {
+    /// 'wait' command
+    cmd: String,
+    /// app's ephemeral public key (optional)
+    #[serde(with = "serde_bytes")]
+    epubkey: Option<Vec<u8>>,
+    /// encrypted CVC value (optional), 6 to 32 bytes
+    #[serde(with = "serde_bytes")]
+    xcvc: Option<Vec<u8>>,
+}
+
+impl WaitCommand {
+    pub fn new(epubkey: Option<Vec<u8>>, xcvc: Option<Vec<u8>>) -> Self {
+        WaitCommand {
+            cmd: Self::name(),
+            epubkey,
+            xcvc,
+        }
+    }
+}
+
+impl CommandApdu for WaitCommand {
+    fn name() -> String {
+        "wait".to_string()
+    }
+}
+
+/// Wait Response
+///
+/// When auth_delay is zero, the CVC can be retried and tested without side effects.
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct WaitResponse {
+    /// command result
+    pub success: bool,
+    /// how much more delay is now required
+    #[serde(default)]
+    pub auth_delay: usize,
+}
+
+impl ResponseApdu for WaitResponse {}
+
+/// New Command
+///
+/// SATSCARD: Use this command to pick a new private key and start a fresh slot. The operation cannot be performed if the current slot is sealed.
+///
+/// TAPSIGNER: This command is only used once.
+///
+/// The slot number is included in the request to prevent command replay.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct NewCommand {
+    /// 'new' command
+    cmd: String,
+    /// (optional: default zero) slot to be affected, must equal currently-active slot number
+    slot: usize,
+    /// app's entropy share to be applied to new slot (optional on SATSCARD), 32 bytes
+    #[serde(with = "serde_bytes")]
+    chain_code: Option<Vec<u8>>,
+    /// app's ephemeral public key, 33 bytes
+    #[serde(with = "serde_bytes")]
+    epubkey: Vec<u8>,
+    /// encrypted CVC value, 6 bytes
+    #[serde(with = "serde_bytes")]
+    xcvc: Vec<u8>,
+}
+
+impl NewCommand {
+    pub fn new(slot: usize, chain_code: Option<Vec<u8>>, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
+        NewCommand {
+            cmd: Self::name(),
+            slot,
+            chain_code,
+            epubkey,
+            xcvc,
+        }
+    }
+}
+
+impl CommandApdu for NewCommand {
+    fn name() -> String {
+        "new".to_string()
+    }
+}
+
+/// New Response
+///
+/// There is a very, very small — 1 in 2128 — chance of arriving at an invalid private key. This
+/// returns error 205 (unlucky number). Retries are allowed with no delay. Also, buy a lottery
+/// ticket immediately.
+///
+/// SATSCARD: derived address is generated based on m/0.
+///
+/// TAPSIGNER: uses the default derivation path of m/84h/0h/0h.
+///
+/// In either case, the status and read commands are required to learn the details of the new
+/// address/key.
+#[derive(Deserialize, Clone, Debug)]
+pub struct NewResponse {
+    /// slot just made
+    pub slot: usize,
+    /// new nonce value, for NEXT command (not this one), 16 bytes
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for NewResponse {}
+
+/// Unseal Command
+///
+/// Unseal the current slot.
+/// NOTE: The slot number is included in the request to prevent command replay. Only the current slot can be unsealed.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct UnsealCommand {
+    /// 'unseal' command
+    cmd: String,
+    /// slot to be unsealed, must equal currently-active slot number
+    slot: usize,
+    /// app's ephemeral public key, 33 bytes
+    #[serde(with = "serde_bytes")]
+    epubkey: Vec<u8>,
+    /// encrypted CVC value, 6 bytes
+    #[serde(with = "serde_bytes")]
+    xcvc: Vec<u8>,
+}
+
+impl UnsealCommand {
+    pub fn new(slot: usize, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
+        UnsealCommand {
+            cmd: Self::name(),
+            slot,
+            epubkey,
+            xcvc,
+        }
+    }
+}
+
+impl CommandApdu for UnsealCommand {
+    fn name() -> String {
+        "unseal".to_string()
+    }
+}
+
+/// Unseal Response
+#[derive(Deserialize, Clone, Debug)]
+pub struct UnsealResponse {
+    /// slot just unsealed
+    pub slot: usize,
+    /// private key for spending (for addr), 32 bytes
+    /// The private keys are encrypted, XORed with the session key
+    #[serde(with = "serde_bytes")]
+    pub privkey: Vec<u8>,
+    /// slot's pubkey (convenience, since could be calc'd from privkey), 33 bytes
+    #[serde(with = "serde_bytes")]
+    pub pubkey: Vec<u8>,
+    /// card's master private key, 32 bytes
+    #[serde(with = "serde_bytes")]
+    pub master_pk: Vec<u8>,
+    /// nonce provided by customer
+    #[serde(with = "serde_bytes")]
+    pub chain_code: Vec<u8>,
+    /// new nonce value, for NEXT command (not this one), 16 bytes
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for UnsealResponse {}
+
+/// Dump Command
+///
+/// This reveals the details for any slot. The current slot is not affected. This is a no-op in
+/// terms of response content, if slots aren't available yet, or if a slot hasn't been unsealed.
+/// The factory uses this to verify the CVC is printed correctly without side effects.
+///
+/// If the epubkey or xcvc is absent, the command still works, but the no sensitive information is
+/// shared.
+///
+/// Incorrect auth values for xcvc will fail as normal. Omit the xcvc and epubkey value to proceed
+/// without authentication if CVC is unknown.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct DumpCommand {
+    /// 'dump' command
+    cmd: String,
+    /// which slot to dump, must be unsealed.
+    slot: usize,
+    /// app's ephemeral public key (optional), 33 bytes
+    #[serde(with = "serde_bytes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    epubkey: Option<Vec<u8>>,
+    /// encrypted CVC value (optional), 6 bytes
+    #[serde(with = "serde_bytes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    xcvc: Option<Vec<u8>>,
+}
+
+impl DumpCommand {
+    pub fn new(slot: usize, epubkey: Option<Vec<u8>>, xcvc: Option<Vec<u8>>) -> Self {
+        DumpCommand {
+            cmd: Self::name(),
+            slot,
+            epubkey,
+            xcvc,
+        }
+    }
+}
+
+impl CommandApdu for DumpCommand {
+    fn name() -> String {
+        "dump".to_string()
+    }
+}
+
+/// Dump Response
+///
+/// Without the CVC, the dump command returns just the sealed/unsealed/unused status for each slot,
+/// with the exception of unsealed slots where the address in full is also provided.
+#[derive(Deserialize, Clone, Debug)]
+pub struct DumpResponse {
+    /// slot just made
+    pub slot: usize,
+    /// private key for spending (for addr), 32 bytes
+    /// The private keys are encrypted, XORed with the session key
+    #[serde(with = "serde_bytes")]
+    #[serde(default)]
+    pub privkey: Option<Vec<u8>>,
+    /// public key, 33 bytes
+    #[serde(with = "serde_bytes")]
+    #[serde(default)]
+    pub pubkey: Vec<u8>,
+    /// nonce provided by customer originally
+    #[serde(with = "serde_bytes")]
+    #[serde(default)]
+    pub chain_code: Option<Vec<u8>>,
+    /// master private key for this slot (was picked by card), 32 bytes
+    #[serde(with = "serde_bytes")]
+    #[serde(default)]
+    pub master_pk: Option<Vec<u8>>,
+    /// flag that slots unsealed for unusual reasons (absent if false)
+    #[serde(default)]
+    pub tampered: Option<bool>,
+    /// if no xcvc provided, slot used status
+    #[serde(default)]
+    pub used: Option<bool>,
+    /// if no xcvc provided, slot sealed status
+    pub sealed: Option<bool>,
+    /// if no xcvc provided, full payment address (not censored)
+    #[serde(default)]
+    pub addr: Option<String>,
+    /// new nonce value, for NEXT command (not this one), 16 bytes
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for DumpResponse {}
+
+/// TAPSIGNER only - Provides the current XPUB (BIP-32 serialized), either at the top level (master) or the derived key in use (see 'path' value in status response)
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct XpubCommand {
+    cmd: String,  // always "xpub"
+    master: bool, // give master (`m`) XPUB, otherwise derived XPUB
+    #[serde(with = "serde_bytes")]
+    epubkey: Vec<u8>, // app's ephemeral public key (required)
+    #[serde(with = "serde_bytes")]
+    xcvc: Vec<u8>, //encrypted CVC value (required)
+}
+
+impl CommandApdu for XpubCommand {
+    fn name() -> String {
+        "xpub".to_string()
+    }
+}
+
+impl XpubCommand {
+    pub fn new(master: bool, epubkey: PublicKey, xcvc: Vec<u8>) -> Self {
+        Self {
+            cmd: Self::name(),
+            master,
+            epubkey: epubkey.serialize().to_vec(),
+            xcvc,
+        }
+    }
+}
+
+#[derive(Deserialize, Clone)]
+pub struct XpubResponse {
+    #[serde(with = "serde_bytes")]
+    pub xpub: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for XpubResponse {}
+
+impl Debug for XpubResponse {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("XpubResponse")
+            .field("xpub", &self.xpub.to_hex())
+            .field("card_nonce", &self.card_nonce.to_hex())
+            .finish()
+    }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,850 +1,209 @@
-use ciborium::de::from_reader;
-use ciborium::ser::into_writer;
-use ciborium::value::Value;
-use secp256k1::hashes::hex::ToHex;
-use secp256k1::PublicKey;
-use serde;
-use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::fmt::{Debug, Formatter};
+use crate::apdu::*;
+use crate::factory_root_key::FactoryRootKey;
+use crate::{CkTapCard, SatsCard, TapSigner};
 
-pub const APP_ID: [u8; 15] = *b"\xf0CoinkiteCARDv1";
-pub const SELECT_CLA_INS_P1P2: [u8; 4] = [0x00, 0xA4, 0x04, 0x00];
-pub const CBOR_CLA_INS_P1P2: [u8; 4] = [0x00, 0xCB, 0x00, 0x00];
+use secp256k1::ecdh::SharedSecret;
+use secp256k1::ecdsa::{RecoverableSignature, RecoveryId, Signature};
+use secp256k1::hashes::{sha256, Hash};
+use secp256k1::{rand, All, Message, PublicKey, Secp256k1, SecretKey};
+use std::convert::TryFrom;
 
-// require nonce sizes (bytes)
-pub const CARD_NONCE_SIZE: usize = 16;
-pub const USER_NONCE_SIZE: usize = 16;
+use std::fmt::Debug;
 
-// Errors
-#[derive(Debug)]
-pub enum Error {
-    CiborDe(String),
-    CiborValue(String),
-    CkTap {
-        error: String,
-        code: usize,
-    },
-    IncorrectSignature(String),
-    #[cfg(feature = "pcsc")]
-    PcSc(String),
+// Helper functions for authenticated commands.
+pub trait Authentication<T: CkTransport> {
+    fn secp(&self) -> &Secp256k1<All>;
+    fn pubkey(&self) -> &PublicKey;
+    fn card_nonce(&self) -> &Vec<u8>;
+    fn set_card_nonce(&mut self, new_nonce: Vec<u8>);
+    fn auth_delay(&self) -> &Option<usize>;
+    fn set_auth_delay(&mut self, auth_delay: Option<usize>);
+
+    fn transport(&self) -> &T;
+
+    fn calc_ekeys_xcvc(&self, cvc: String, command: &str) -> (SecretKey, PublicKey, Vec<u8>) {
+        let secp = Self::secp(self);
+        let pubkey = Self::pubkey(self);
+        let nonce = Self::card_nonce(self);
+        let cvc_bytes = cvc.as_bytes();
+        let card_nonce_bytes = nonce.as_slice();
+        let card_nonce_command = [card_nonce_bytes, command.as_bytes()].concat();
+        let (eprivkey, epubkey) = secp.generate_keypair(&mut rand::thread_rng());
+        let session_key = SharedSecret::new(pubkey, &eprivkey);
+
+        let md = sha256::Hash::hash(card_nonce_command.as_slice());
+
+        let mask: Vec<u8> = session_key
+            .as_ref()
+            .iter()
+            .zip(md.as_ref())
+            .map(|(x, y)| x ^ y)
+            .take(cvc_bytes.len())
+            .collect();
+        let xcvc = cvc_bytes.iter().zip(mask).map(|(x, y)| x ^ y).collect();
+        (eprivkey, epubkey, xcvc)
+    }
 }
 
-impl<T> From<ciborium::de::Error<T>> for Error
+pub trait CkTransport: Sized {
+    fn transmit<'a, C, R>(&self, command: C) -> Result<R, Error>
+    where
+        C: CommandApdu + serde::Serialize + Debug,
+        R: ResponseApdu + serde::Deserialize<'a> + Debug,
+    {
+        let command_apdu = command.apdu_bytes();
+        let rapdu = self.transmit_apdu(command_apdu)?;
+        let response = R::from_cbor(rapdu.to_vec())?;
+        Ok(response)
+    }
+    fn transmit_apdu(&self, command_apdu: Vec<u8>) -> Result<Vec<u8>, Error>;
+
+    fn to_cktap(self) -> Result<CkTapCard<Self>, Error> {
+        // Get status from card
+        let cmd = AppletSelect::default();
+        let status_response: StatusResponse = self.transmit(cmd)?;
+
+        // Return correct card variant using status
+        match (status_response.tapsigner, status_response.satschip) {
+            (Some(true), None) => Ok(CkTapCard::TapSigner(TapSigner::from_status(
+                self,
+                status_response,
+            ))),
+            (Some(true), Some(true)) => Ok(CkTapCard::TapSigner(TapSigner::from_status(
+                self,
+                status_response,
+            ))),
+            (None, None) => Ok(CkTapCard::SatsCard(
+                SatsCard::from_status(self, status_response).unwrap(),
+            )),
+            (_, _) => Err(Error::UnknownCardType("Card not recognized.".to_string())),
+        }
+    }
+}
+
+// card traits
+pub trait Read<T>: Authentication<T>
 where
-    T: Debug,
+    T: CkTransport,
 {
-    fn from(e: ciborium::de::Error<T>) -> Self {
-        Error::CiborDe(e.to_string())
-    }
-}
+    fn requires_auth(&self) -> bool;
 
-impl From<ciborium::value::Error> for Error {
-    fn from(e: ciborium::value::Error) -> Self {
-        Error::CiborValue(e.to_string())
-    }
-}
-
-impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Self {
-        Error::IncorrectSignature(e.to_string())
-    }
-}
-
-#[cfg(feature = "pcsc")]
-impl From<pcsc::Error> for Error {
-    fn from(e: pcsc::Error) -> Self {
-        Error::PcSc(e.to_string())
-    }
-}
-
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct ErrorResponse {
-    pub error: String,
-    pub code: usize,
-}
-
-// Apdu Traits
-pub trait CommandApdu {
-    fn name() -> String;
-    fn apdu_bytes(&self) -> Vec<u8>
-    where
-        Self: serde::Serialize + Debug,
-    {
-        let mut command = Vec::new();
-        into_writer(&self, &mut command).unwrap();
-        build_apdu(&CBOR_CLA_INS_P1P2, command.as_slice())
-    }
-}
-
-pub trait ResponseApdu {
-    fn from_cbor<'a>(cbor: Vec<u8>) -> Result<Self, Error>
-    where
-        Self: Deserialize<'a> + Debug,
-    {
-        let cbor_value: Value = from_reader(&cbor[..])?;
-        let cbor_struct: Result<ErrorResponse, _> = cbor_value.deserialized();
-        if let Ok(error_resp) = cbor_struct {
-            return Err(Error::CkTap {
-                error: error_resp.error,
-                code: error_resp.code,
-            });
+    fn read(&mut self, cvc: Option<String>) -> Result<ReadResponse, Error> {
+        let cmd = if self.requires_auth() {
+            let (_, epubkey, xcvc) = self.calc_ekeys_xcvc(cvc.unwrap(), &ReadCommand::name());
+            ReadCommand::authenticated(self.card_nonce().clone(), epubkey, xcvc)
+        } else {
+            ReadCommand::unauthenticated(self.card_nonce().clone())
+        };
+        let read_response: Result<ReadResponse, Error> = self.transport().transmit(cmd);
+        if let Ok(response) = &read_response {
+            self.set_card_nonce(response.card_nonce.clone());
         }
-        let cbor_struct: Self = cbor_value.deserialized()?;
-        Ok(cbor_struct)
+        read_response
     }
 }
 
-fn build_apdu(header: &[u8], command: &[u8]) -> Vec<u8> {
-    let command_len = command.len();
-    assert!(command_len <= 255, "apdu command too long"); // TODO use Err
-    [header, &[command_len as u8], command].concat()
-}
+pub trait Wait<T>: Authentication<T>
+where
+    T: CkTransport,
+{
+    fn wait(&mut self, cvc: Option<String>) -> Result<WaitResponse, Error> {
+        let epubkey_xcvc = cvc.map(|cvc| {
+            let (_, epubkey, xcvc) = self.calc_ekeys_xcvc(cvc, &WaitCommand::name());
+            (epubkey, xcvc)
+        });
 
-/// Applet Select
-#[derive(Default, Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct AppletSelect {}
+        let (epubkey, xcvc) = epubkey_xcvc
+            .map(|(epubkey, xcvc)| (Some(epubkey.serialize().to_vec()), Some(xcvc)))
+            .unwrap_or((None, None));
 
-impl CommandApdu for AppletSelect {
-    fn name() -> String {
-        String::default()
-    }
-    fn apdu_bytes(&self) -> Vec<u8> {
-        build_apdu(&SELECT_CLA_INS_P1P2, &APP_ID)
-    }
-}
-
-/// Status Command
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct StatusCommand {
-    /// 'status' command
-    cmd: String,
-}
-
-impl Default for StatusCommand {
-    fn default() -> Self {
-        StatusCommand { cmd: Self::name() }
-    }
-}
-
-impl CommandApdu for StatusCommand {
-    fn name() -> String {
-        "status".to_string()
-    }
-}
-
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct StatusResponse {
-    pub proto: usize,
-    pub ver: String,
-    pub birth: usize,
-    pub slots: Option<(usize, usize)>,
-    pub addr: Option<String>,
-    pub tapsigner: Option<bool>,
-    pub satschip: Option<bool>,
-    pub path: Option<Vec<usize>>,
-    pub num_backups: Option<usize>,
-    #[serde(with = "serde_bytes")]
-    pub pubkey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
-    pub testnet: Option<bool>,
-    #[serde(default)]
-    pub auth_delay: Option<usize>,
-}
-
-impl ResponseApdu for StatusResponse {}
-
-/// Read Command
-///
-/// Apps need to write a CBOR message to read a SATSCARD's current payment address, or a
-/// TAPSIGNER's derived public key.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct ReadCommand {
-    /// 'read' command
-    cmd: String,
-    /// provided by app, cannot be all same byte (& should be random), 16 bytes
-    #[serde(with = "serde_bytes")]
-    nonce: Vec<u8>,
-    /// (TAPSIGNER only) auth is required, 33 bytes
-    #[serde(with = "serde_bytes")]
-    epubkey: Option<Vec<u8>>,
-    /// (TAPSIGNER only) auth is required encrypted CVC value, 6 to 32 bytes
-    #[serde(with = "serde_bytes")]
-    xcvc: Option<Vec<u8>>,
-}
-
-impl ReadCommand {
-    pub fn for_tapsigner(nonce: Vec<u8>, epubkey: PublicKey, xcvc: Vec<u8>) -> Self {
-        ReadCommand {
-            cmd: Self::name(),
-            nonce,
-            epubkey: Some(epubkey.serialize().to_vec()),
-            xcvc: Some(xcvc),
+        let wait_command = WaitCommand::new(epubkey, xcvc);
+        let wait_response: Result<WaitResponse, Error> = self.transport().transmit(wait_command);
+        if let Ok(response) = &wait_response {
+            if response.auth_delay > 0 {
+                self.set_auth_delay(Some(response.auth_delay));
+            } else {
+                self.set_auth_delay(None);
+            }
         }
+        wait_response
     }
+}
 
-    pub fn for_satscard(nonce: Vec<u8>) -> Self {
-        ReadCommand {
-            cmd: Self::name(),
-            nonce,
-            epubkey: None,
-            xcvc: None,
+pub trait Certificate<T>: Authentication<T>
+where
+    T: CkTransport,
+{
+    fn message_digest(&mut self, card_nonce: Vec<u8>, app_nonce: Vec<u8>) -> Message;
+
+    fn check_certificate(&mut self, nonce: Vec<u8>) -> Result<FactoryRootKey, Error> {
+        let card_nonce = self.card_nonce().clone();
+
+        let certs_cmd = CertsCommand::default();
+        let certs_response: CertsResponse = self.transport().transmit(certs_cmd)?;
+
+        let check_cmd = CheckCommand::new(nonce.clone());
+        let check_response: Result<CheckResponse, Error> = self.transport().transmit(check_cmd);
+        if let Ok(response) = &check_response {
+            self.set_card_nonce(response.card_nonce.clone());
         }
+
+        self.verify_card_signature(check_response.unwrap().auth_sig, card_nonce, nonce)?;
+
+        let mut pubkey = *self.pubkey();
+        for sig in &certs_response.cert_chain() {
+            // BIP-137: https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki
+            let subtract_by = match sig[0] {
+                27..=30 => 27, // P2PKH uncompressed
+                31..=34 => 31, // P2PKH compressed
+                35..=38 => 35, // Segwit P2SH
+                39..=42 => 39, // Segwit Bech32
+                _ => panic!("Unrecognized BIP-137 address"),
+            };
+            let rec_id = RecoveryId::from_i32((sig[0] as i32) - subtract_by).unwrap();
+            let (_, sig) = sig.split_at(1);
+            let rec_sig = RecoverableSignature::from_compact(sig, rec_id).unwrap();
+            let md = Message::from_hashed_data::<sha256::Hash>(&pubkey.serialize());
+            pubkey = self.secp().recover_ecdsa(&md, &rec_sig).unwrap();
+        }
+
+        FactoryRootKey::try_from(pubkey)
+    }
+
+    fn verify_card_signature(
+        &mut self,
+        signature: Vec<u8>,
+        card_nonce: Vec<u8>,
+        app_nonce: Vec<u8>,
+    ) -> Result<(), secp256k1::Error> {
+        let message = self.message_digest(card_nonce, app_nonce);
+        let signature = Signature::from_compact(signature.as_slice())
+            .expect("Failed to construct ECDSA signature from check response");
+        self.secp()
+            .verify_ecdsa(&message, &signature, self.pubkey())
     }
 }
 
-impl CommandApdu for ReadCommand {
-    fn name() -> String {
-        "read".to_string()
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
 
-/// Read Response
-///
-/// The signature is created from the digest (SHA-256) of these bytes:
-///
-/// b'OPENDIME' (8 bytes)
-/// (card_nonce - 16 bytes)
-/// (nonce from read command - 16 bytes)
-/// (slot - 1 byte)
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct ReadResponse {
-    /// signature over a bunch of fields using private key of slot, 64 bytes
-    #[serde(with = "serde_bytes")]
-    pub sig: Vec<u8>,
-    /// public key for this slot/derivation, 33 bytes
-    #[serde(with = "serde_bytes")]
-    pub pubkey: Vec<u8>,
-    /// new nonce value, for NEXT command (not this one), 16 bytes
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
-}
+//     #[test]
+//     fn test_tapsigner_signature() {
+//         let card_pubkey = PublicKey::from_slice(
+//             &from_hex("0335170d9b853440080b0e5d6129f985ebeb919e7a90f28a5fa15c7987ec986a6b")
+//                 .as_slice(),
+//         )
+//         .map_err(|e| Error::CiborValue(e.to_string()))
+//         .unwrap();
+//         let signature: Vec<u8> = from_hex("44721225a42eb3496cc38858adf8fafde9a752776d36c719aaa4f255ab121a0864be7d21eb47a5db88e3879b53ea74794d3e9503cc9b56b8bf9f948324198c30");
+//         let card_nonce: Vec<u8> = from_hex("fd4c5d2c9d9c5a647cbc0b2b79ffef91");
+//         let app_nonce: Vec<u8> = from_hex("273faf8a0b270f697bcb6c90dc8cd4ba");
+//         let secp = Secp256k1::new();
 
-impl ResponseApdu for ReadResponse {}
-
-impl Debug for ReadResponse {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_struct("ReadResponse")
-            .field("sig", &self.sig.to_hex())
-            .field("pubkey", &self.pubkey.to_hex())
-            .field("card_nonce", &self.card_nonce.to_hex())
-            .finish()
-    }
-}
-
-// impl ReadResponse {
-//     pub fn pubkey(&self) -> PublicKey {
-//         PublicKey::from_slice(self.pubkey.as_slice()).unwrap()
+//         assert!(
+//             verify_tapsigner_signature(&card_pubkey, signature, card_nonce, app_nonce, &secp)
+//                 .is_ok()
+//         );
 //     }
 // }
-
-// Checks payment address derivation: https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#satscard-checks-payment-address-derivation
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct DeriveCommand {
-    cmd: String,
-    /// provided by app, cannot be all same byte (& should be random), 16 bytes
-    #[serde(with = "serde_bytes")]
-    nonce: Vec<u8>,
-    path: Option<Vec<usize>>,
-    #[serde(with = "serde_bytes")]
-    epubkey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    xcvc: Option<Vec<u8>>,
-}
-
-impl CommandApdu for DeriveCommand {
-    fn name() -> String {
-        "derive".to_string()
-    }
-}
-
-impl DeriveCommand {
-    pub fn for_satscard(nonce: Vec<u8>) -> Self {
-        DeriveCommand {
-            cmd: Self::name(),
-            nonce,
-            path: None,
-            epubkey: None,
-            xcvc: None,
-        }
-    }
-
-    pub fn for_tapsigner(
-        nonce: Vec<u8>,
-        path: Vec<usize>,
-        epubkey: PublicKey,
-        xcvc: Vec<u8>,
-    ) -> Self {
-        DeriveCommand {
-            cmd: Self::name(),
-            nonce,
-            path: Some(path),
-            epubkey: Some(epubkey.serialize().to_vec()),
-            xcvc: Some(xcvc),
-        }
-    }
-}
-
-#[derive(Deserialize, Clone)]
-pub struct DeriveResponse {
-    #[serde(with = "serde_bytes")]
-    pub sig: Vec<u8>, // 64 byes
-    #[serde(with = "serde_bytes")]
-    pub chain_code: Vec<u8>, // 32 bytes
-    #[serde(with = "serde_bytes")]
-    pub master_pubkey: Vec<u8>, // 33 bytes
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>, // 16 bytes
-}
-
-impl ResponseApdu for DeriveResponse {}
-
-impl Debug for DeriveResponse {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_struct("DeriveResponse")
-            .field("sig", &self.sig.to_hex())
-            .field("chain_code", &self.chain_code.to_hex())
-            .field("master_pubkey", &self.master_pubkey.to_hex())
-            .field("card_nonce", &self.card_nonce.to_hex())
-            .finish()
-    }
-}
-
-/// Certs Command
-///
-/// This command is used to verify the card was made by Coinkite and is not counterfeit. Two
-/// requests are needed: first, fetch the certificates, and then provide a nonce to be signed.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct CertsCommand {
-    /// 'certs' command
-    cmd: String,
-}
-
-impl CommandApdu for CertsCommand {
-    fn name() -> String {
-        "certs".to_string()
-    }
-}
-
-impl Default for CertsCommand {
-    fn default() -> Self {
-        CertsCommand { cmd: Self::name() }
-    }
-}
-
-/// The response is static for any particular card. The values are captured during factory setup.
-/// Each entry in the list is a 65-byte signature. The first signature signs the card's public key,
-/// and each following signature signs the public key used in the previous signature. Although two
-/// levels of signatures are planned, more are possible.
-#[derive(Deserialize, Clone)]
-pub struct CertsResponse {
-    /// list of certificates, from 'batch' to 'root'
-    // TODO create custom deserializer like "serde_bytes" but for Vec<Vec<u8>>
-    cert_chain: Vec<Value>,
-}
-
-impl ResponseApdu for CertsResponse {}
-
-impl CertsResponse {
-    pub fn cert_chain(&self) -> Vec<Vec<u8>> {
-        self.clone()
-            .cert_chain
-            .into_iter()
-            .filter_map(|v| match v {
-                Value::Bytes(bv) => Some(bv),
-                _ => None,
-            })
-            .collect()
-    }
-}
-
-impl Debug for CertsResponse {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let cert_hexes: Vec<String> = self.cert_chain().iter().map(|key| key.to_hex()).collect();
-        f.debug_struct("CertsResponse")
-            .field("cert_chain", &cert_hexes)
-            .finish()
-    }
-}
-
-/// Check Command
-///
-/// This command is used to verify the card was made by Coinkite and is not counterfeit. Two
-/// requests are needed: first, fetch the certificates (i.e CertsCommand), and then provide a nonce to be signed.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct CheckCommand {
-    /// 'check' command
-    cmd: String,
-    /// random value from app, 16 bytes
-    #[serde(with = "serde_bytes")]
-    nonce: Vec<u8>,
-}
-
-impl CommandApdu for CheckCommand {
-    fn name() -> String {
-        "check".to_string()
-    }
-}
-
-impl CheckCommand {
-    pub fn new(nonce: Vec<u8>) -> Self {
-        CheckCommand {
-            cmd: Self::name(),
-            nonce,
-        }
-    }
-}
-
-/// Check Certs Response
-/// ref: https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#certs
-#[derive(Deserialize, Clone)]
-pub struct CheckResponse {
-    /// signature using card_pubkey, 64 bytes
-    #[serde(with = "serde_bytes")]
-    pub auth_sig: Vec<u8>,
-    /// new nonce value, for NEXT command (not this one), 16 bytes
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
-}
-
-impl ResponseApdu for CheckResponse {}
-
-impl Debug for CheckResponse {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_struct("CheckResponse")
-            .field("auth_sig", &self.auth_sig.to_hex())
-            .field("card_nonce", &self.card_nonce.to_hex())
-            .finish()
-    }
-}
-
-/// nfc command to return dynamic url for NFC-enabled smart phone
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct NfcCommand {
-    cmd: String,
-}
-
-impl Default for NfcCommand {
-    fn default() -> Self {
-        Self { cmd: Self::name() }
-    }
-}
-
-impl CommandApdu for NfcCommand {
-    fn name() -> String {
-        "nfc".to_string()
-    }
-}
-
-/// nfc Response
-///
-/// URL for smart phone to navigate to
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct NfcResponse {
-    /// command result
-    pub url: String,
-}
-
-impl ResponseApdu for NfcResponse {}
-
-/// Sign Command
-// {
-//     'cmd': 'sign',              # command
-//     'slot': 0,                  # (optional) which slot's to key to use, must be unsealed.
-//     'subpath': [0, 0],          # (TAPSIGNER only) additional derivation keypath to be used
-//     'digest': (32 bytes),        # message digest to be signed
-//     'epubkey': (33 bytes),       # app's ephemeral public key
-//     'xcvc': (6 bytes)          # encrypted CVC value
-// }
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct SignCommand {
-    cmd: String,
-    slot: Option<u8>,
-    subpath: Option<[u32; 2]>,
-    // additional keypath for TapSigner only
-    #[serde(with = "serde_bytes")]
-    digest: Vec<u8>,
-    // message digest to be signed
-    #[serde(with = "serde_bytes")]
-    epubkey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    xcvc: Vec<u8>,
-}
-
-impl SignCommand {
-    // pub fn for_satscard(slot: Option<u8>, digest: Vec<u8>, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
-    //     Self {
-    //         cmd: "sign".to_string(),
-    //         slot,
-    //         digest,
-    //         subpath: None,
-    //         epubkey,
-    //         xcvc,
-    //     }
-    // }
-
-    pub fn for_tapsigner(
-        subpath: Option<[u32; 2]>,
-        digest: Vec<u8>,
-        epubkey: PublicKey,
-        xcvc: Vec<u8>,
-    ) -> Self {
-        let cmd = Self::name();
-
-        SignCommand {
-            cmd,
-            slot: Some(0),
-            subpath,
-            digest,
-            epubkey: epubkey.serialize().to_vec(),
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for SignCommand {
-    fn name() -> String {
-        "sign".to_string()
-    }
-}
-
-/// Sign Response
-// SATSCARD: Arbitrary signatures can be created for unsealed slots. The app could perform this, since the private key is known, but it's best if the app isn't contaminated with private key information. This could be used for both spending and multisig wallet operations.
-//
-// TAPSIGNER: This is its core feature — signing an arbitrary message digest with a tap. Once the card is set up (the key is picked), the command will always be valid.
-#[derive(Deserialize, Clone, PartialEq, Eq)]
-pub struct SignResponse {
-    /// command result
-    pub slot: u8,
-    #[serde(with = "serde_bytes")]
-    pub sig: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub pubkey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
-}
-
-impl ResponseApdu for SignResponse {}
-
-impl Debug for SignResponse {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_struct("SignResponse")
-            .field("slot", &self.slot)
-            .field("sig", &self.sig.to_hex())
-            .field("pubkey", &self.pubkey.to_hex())
-            .field("card_nonce", &self.card_nonce.to_hex())
-            .finish()
-    }
-}
-
-/// Wait Command
-///
-/// Invalid CVC codes return error 401 (bad auth), through the third incorrect attempt. After the
-/// third incorrect attempt, a 15-second delay is required. Any further attempts to authenticate
-/// will return error 429 (rate limited) until the delay has passed.
-///
-/// In rate-limiting mode, the status command returns the auth_delay field with a positive value.
-///
-/// The wait command takes one second to execute and reduces the auth_delay by one unit. Typically,
-/// 15 wait commands need to be executed before retrying a CVC.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct WaitCommand {
-    /// 'wait' command
-    cmd: String,
-    /// app's ephemeral public key (optional)
-    #[serde(with = "serde_bytes")]
-    epubkey: Option<Vec<u8>>,
-    /// encrypted CVC value (optional), 6 to 32 bytes
-    #[serde(with = "serde_bytes")]
-    xcvc: Option<Vec<u8>>,
-}
-
-impl WaitCommand {
-    pub fn new(epubkey: Option<Vec<u8>>, xcvc: Option<Vec<u8>>) -> Self {
-        WaitCommand {
-            cmd: Self::name(),
-            epubkey,
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for WaitCommand {
-    fn name() -> String {
-        "wait".to_string()
-    }
-}
-
-/// Wait Response
-///
-/// When auth_delay is zero, the CVC can be retried and tested without side effects.
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct WaitResponse {
-    /// command result
-    pub success: bool,
-    /// how much more delay is now required
-    #[serde(default)]
-    pub auth_delay: usize,
-}
-
-impl ResponseApdu for WaitResponse {}
-
-/// New Command
-///
-/// SATSCARD: Use this command to pick a new private key and start a fresh slot. The operation cannot be performed if the current slot is sealed.
-///
-/// TAPSIGNER: This command is only used once.
-///
-/// The slot number is included in the request to prevent command replay.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct NewCommand {
-    /// 'new' command
-    cmd: String,
-    /// (optional: default zero) slot to be affected, must equal currently-active slot number
-    slot: usize,
-    /// app's entropy share to be applied to new slot (optional on SATSCARD), 32 bytes
-    #[serde(with = "serde_bytes")]
-    chain_code: Option<Vec<u8>>,
-    /// app's ephemeral public key, 33 bytes
-    #[serde(with = "serde_bytes")]
-    epubkey: Vec<u8>,
-    /// encrypted CVC value, 6 bytes
-    #[serde(with = "serde_bytes")]
-    xcvc: Vec<u8>,
-}
-
-impl NewCommand {
-    pub fn new(slot: usize, chain_code: Option<Vec<u8>>, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
-        NewCommand {
-            cmd: Self::name(),
-            slot,
-            chain_code,
-            epubkey,
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for NewCommand {
-    fn name() -> String {
-        "new".to_string()
-    }
-}
-
-/// New Response
-///
-/// There is a very, very small — 1 in 2128 — chance of arriving at an invalid private key. This
-/// returns error 205 (unlucky number). Retries are allowed with no delay. Also, buy a lottery
-/// ticket immediately.
-///
-/// SATSCARD: derived address is generated based on m/0.
-///
-/// TAPSIGNER: uses the default derivation path of m/84h/0h/0h.
-///
-/// In either case, the status and read commands are required to learn the details of the new
-/// address/key.
-#[derive(Deserialize, Clone, Debug)]
-pub struct NewResponse {
-    /// slot just made
-    pub slot: usize,
-    /// new nonce value, for NEXT command (not this one), 16 bytes
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
-}
-
-impl ResponseApdu for NewResponse {}
-
-/// Unseal Command
-///
-/// Unseal the current slot.
-/// NOTE: The slot number is included in the request to prevent command replay. Only the current slot can be unsealed.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct UnsealCommand {
-    /// 'unseal' command
-    cmd: String,
-    /// slot to be unsealed, must equal currently-active slot number
-    slot: usize,
-    /// app's ephemeral public key, 33 bytes
-    #[serde(with = "serde_bytes")]
-    epubkey: Vec<u8>,
-    /// encrypted CVC value, 6 bytes
-    #[serde(with = "serde_bytes")]
-    xcvc: Vec<u8>,
-}
-
-impl UnsealCommand {
-    pub fn new(slot: usize, epubkey: Vec<u8>, xcvc: Vec<u8>) -> Self {
-        UnsealCommand {
-            cmd: Self::name(),
-            slot,
-            epubkey,
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for UnsealCommand {
-    fn name() -> String {
-        "unseal".to_string()
-    }
-}
-
-/// Unseal Response
-#[derive(Deserialize, Clone, Debug)]
-pub struct UnsealResponse {
-    /// slot just unsealed
-    pub slot: usize,
-    /// private key for spending (for addr), 32 bytes
-    /// The private keys are encrypted, XORed with the session key
-    #[serde(with = "serde_bytes")]
-    pub privkey: Vec<u8>,
-    /// slot's pubkey (convenience, since could be calc'd from privkey), 33 bytes
-    #[serde(with = "serde_bytes")]
-    pub pubkey: Vec<u8>,
-    /// card's master private key, 32 bytes
-    #[serde(with = "serde_bytes")]
-    pub master_pk: Vec<u8>,
-    /// nonce provided by customer
-    #[serde(with = "serde_bytes")]
-    pub chain_code: Vec<u8>,
-    /// new nonce value, for NEXT command (not this one), 16 bytes
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
-}
-
-impl ResponseApdu for UnsealResponse {}
-
-/// Dump Command
-///
-/// This reveals the details for any slot. The current slot is not affected. This is a no-op in
-/// terms of response content, if slots aren't available yet, or if a slot hasn't been unsealed.
-/// The factory uses this to verify the CVC is printed correctly without side effects.
-///
-/// If the epubkey or xcvc is absent, the command still works, but the no sensitive information is
-/// shared.
-///
-/// Incorrect auth values for xcvc will fail as normal. Omit the xcvc and epubkey value to proceed
-/// without authentication if CVC is unknown.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct DumpCommand {
-    /// 'dump' command
-    cmd: String,
-    /// which slot to dump, must be unsealed.
-    slot: usize,
-    /// app's ephemeral public key (optional), 33 bytes
-    #[serde(with = "serde_bytes")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    epubkey: Option<Vec<u8>>,
-    /// encrypted CVC value (optional), 6 bytes
-    #[serde(with = "serde_bytes")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    xcvc: Option<Vec<u8>>,
-}
-
-impl DumpCommand {
-    pub fn new(slot: usize, epubkey: Option<Vec<u8>>, xcvc: Option<Vec<u8>>) -> Self {
-        DumpCommand {
-            cmd: Self::name(),
-            slot,
-            epubkey,
-            xcvc,
-        }
-    }
-}
-
-impl CommandApdu for DumpCommand {
-    fn name() -> String {
-        "dump".to_string()
-    }
-}
-
-/// Dump Response
-///
-/// Without the CVC, the dump command returns just the sealed/unsealed/unused status for each slot,
-/// with the exception of unsealed slots where the address in full is also provided.
-#[derive(Deserialize, Clone, Debug)]
-pub struct DumpResponse {
-    /// slot just made
-    pub slot: usize,
-    /// private key for spending (for addr), 32 bytes
-    /// The private keys are encrypted, XORed with the session key
-    #[serde(with = "serde_bytes")]
-    #[serde(default)]
-    pub privkey: Option<Vec<u8>>,
-    /// public key, 33 bytes
-    #[serde(with = "serde_bytes")]
-    #[serde(default)]
-    pub pubkey: Vec<u8>,
-    /// nonce provided by customer originally
-    #[serde(with = "serde_bytes")]
-    #[serde(default)]
-    pub chain_code: Option<Vec<u8>>,
-    /// master private key for this slot (was picked by card), 32 bytes
-    #[serde(with = "serde_bytes")]
-    #[serde(default)]
-    pub master_pk: Option<Vec<u8>>,
-    /// flag that slots unsealed for unusual reasons (absent if false)
-    #[serde(default)]
-    pub tampered: Option<bool>,
-    /// if no xcvc provided, slot used status
-    #[serde(default)]
-    pub used: Option<bool>,
-    /// if no xcvc provided, slot sealed status
-    pub sealed: Option<bool>,
-    /// if no xcvc provided, full payment address (not censored)
-    #[serde(default)]
-    pub addr: Option<String>,
-    /// new nonce value, for NEXT command (not this one), 16 bytes
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
-}
-
-impl ResponseApdu for DumpResponse {}
-
-/// TAPSIGNER only - Provides the current XPUB (BIP-32 serialized), either at the top level (master) or the derived key in use (see 'path' value in status response)
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct XpubCommand {
-    cmd: String,  // always "xpub"
-    master: bool, // give master (`m`) XPUB, otherwise derived XPUB
-    #[serde(with = "serde_bytes")]
-    epubkey: Vec<u8>, // app's ephemeral public key (required)
-    #[serde(with = "serde_bytes")]
-    xcvc: Vec<u8>, //encrypted CVC value (required)
-}
-
-impl CommandApdu for XpubCommand {
-    fn name() -> String {
-        "xpub".to_string()
-    }
-}
-
-impl XpubCommand {
-    pub fn new(master: bool, epubkey: PublicKey, xcvc: Vec<u8>) -> Self {
-        Self {
-            cmd: Self::name(),
-            master,
-            epubkey: epubkey.serialize().to_vec(),
-            xcvc,
-        }
-    }
-}
-
-#[derive(Deserialize, Clone)]
-pub struct XpubResponse {
-    #[serde(with = "serde_bytes")]
-    pub xpub: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub card_nonce: Vec<u8>,
-}
-
-impl ResponseApdu for XpubResponse {}
-
-impl Debug for XpubResponse {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_struct("XpubResponse")
-            .field("xpub", &self.xpub.to_hex())
-            .field("card_nonce", &self.card_nonce.to_hex())
-            .finish()
-    }
-}

--- a/src/factory_root_key.rs
+++ b/src/factory_root_key.rs
@@ -1,4 +1,4 @@
-use crate::commands::Error;
+use crate::apdu::Error;
 use secp256k1::hashes::hex::ToHex;
 use secp256k1::PublicKey;
 use std::convert::TryFrom;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,48 +1,27 @@
-use secp256k1::ecdh::SharedSecret;
-use secp256k1::ecdsa::{RecoverableSignature, RecoveryId, Signature};
-use secp256k1::hashes::{sha256, Hash};
-
+use secp256k1::hashes::sha256;
 use secp256k1::rand::rngs::ThreadRng;
 use secp256k1::rand::Rng;
-use secp256k1::{rand, All, Message, PublicKey, Secp256k1, SecretKey};
-use std::convert::TryFrom;
+use secp256k1::{All, Message, PublicKey, Secp256k1};
 use std::fmt;
 use std::fmt::Debug;
 
+pub mod apdu;
 pub mod commands;
 pub mod factory_root_key;
 
 #[cfg(feature = "pcsc")]
 pub mod pcsc;
 
+use apdu::*;
 use commands::*;
-use factory_root_key::FactoryRootKey;
 
-pub trait Transport {
-    fn find_first() -> Result<CkTapCard<Self>, Error>
-    where
-        Self: Sized;
-    //fn find_cards() -> Vec<CkTapCard<Self>>;
-    fn transmit<'a, C, R>(&self, command: C) -> Result<R, Error>
-    where
-        C: CommandApdu + serde::Serialize + Debug,
-        R: ResponseApdu + serde::Deserialize<'a> + Debug,
-    {
-        let command_apdu = command.apdu_bytes();
-        let rapdu = self.transmit_apdu(command_apdu)?;
-        let response = R::from_cbor(rapdu.to_vec())?;
-        Ok(response)
-    }
-    fn transmit_apdu(&self, command_apdu: Vec<u8>) -> Result<Vec<u8>, Error>;
-}
-
-pub enum CkTapCard<T: Transport + Sized> {
+pub enum CkTapCard<T: CkTransport> {
+    SatsCard(SatsCard<T>),
     TapSigner(TapSigner<T>),
     SatsChip(TapSigner<T>),
-    SatsCard(SatsCard<T>),
 }
 
-impl<T: Transport + Sized> fmt::Debug for CkTapCard<T> {
+impl<T: CkTransport> fmt::Debug for CkTapCard<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             CkTapCard::TapSigner(t) => {
@@ -58,7 +37,7 @@ impl<T: Transport + Sized> fmt::Debug for CkTapCard<T> {
     }
 }
 
-pub struct TapSigner<T: Transport + Sized> {
+pub struct TapSigner<T: CkTransport> {
     pub transport: T,
     pub secp: Secp256k1<All>,
     pub proto: usize,
@@ -72,7 +51,7 @@ pub struct TapSigner<T: Transport + Sized> {
     pub auth_delay: Option<usize>,
 }
 
-impl<T: Transport> Authentication for TapSigner<T> {
+impl<T: CkTransport> Authentication<T> for TapSigner<T> {
     fn secp(&self) -> &Secp256k1<All> {
         &self.secp
     }
@@ -96,38 +75,13 @@ impl<T: Transport> Authentication for TapSigner<T> {
     fn set_auth_delay(&mut self, auth_delay: Option<usize>) {
         self.auth_delay = auth_delay;
     }
-}
 
-impl<T: Transport> SharedCommands<T> for TapSigner<T> {
     fn transport(&self) -> &T {
         &self.transport
     }
-
-    fn signed_message(&mut self, card_nonce: Vec<u8>, app_nonce: Vec<u8>) -> Vec<u8> {
-        let mut message_bytes: Vec<u8> = Vec::new();
-        message_bytes.extend("OPENDIME".as_bytes());
-        message_bytes.extend(card_nonce);
-        message_bytes.extend(app_nonce);
-        message_bytes
-    }
 }
 
-impl<T: Transport + Sized> Debug for TapSigner<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TapSigner")
-            .field("proto", &self.proto)
-            .field("ver", &self.ver)
-            .field("birth", &self.birth)
-            .field("path", &self.path)
-            .field("num_backups", &self.num_backups)
-            .field("pubkey", &self.pubkey)
-            .field("card_nonce", &self.card_nonce)
-            .field("auth_delay", &self.auth_delay)
-            .finish()
-    }
-}
-
-impl<T: Transport + Sized> TapSigner<T> {
+impl<T: CkTransport> TapSigner<T> {
     pub fn from_status(transport: T, status_response: StatusResponse) -> Self {
         let pubkey = status_response.pubkey.as_slice(); // TODO verify is 33 bytes?
         let pubkey = PublicKey::from_slice(pubkey)
@@ -159,16 +113,6 @@ impl<T: Transport + Sized> TapSigner<T> {
         new_response
     }
 
-    pub fn read(&mut self, cvc: String) -> Result<ReadResponse, Error> {
-        let (_, epubkey, xcvc) = self.calc_ekeys_xcvc(cvc, &ReadCommand::name());
-        let read_command = ReadCommand::for_tapsigner(self.card_nonce.clone(), epubkey, xcvc);
-        let read_response: Result<ReadResponse, Error> = self.transport.transmit(read_command);
-        if let Ok(response) = &read_response {
-            self.card_nonce = response.card_nonce.clone();
-        }
-        read_response
-    }
-
     pub fn derive(&mut self, path: Vec<usize>, cvc: String) -> Result<DeriveResponse, Error> {
         let (_, epubkey, xcvc) = self.calc_ekeys_xcvc(cvc, &DeriveCommand::name());
         let cmd = DeriveCommand::for_tapsigner(self.card_nonce.clone(), path, epubkey, xcvc);
@@ -188,7 +132,40 @@ impl<T: Transport + Sized> TapSigner<T> {
     }
 }
 
-pub struct SatsCard<T: Transport + Sized> {
+impl<T: CkTransport> Wait<T> for TapSigner<T> {}
+
+impl<T: CkTransport> Read<T> for TapSigner<T> {
+    fn requires_auth(&self) -> bool {
+        true
+    }
+}
+
+impl<T: CkTransport> Certificate<T> for TapSigner<T> {
+    fn message_digest(&mut self, card_nonce: Vec<u8>, app_nonce: Vec<u8>) -> Message {
+        let mut message_bytes: Vec<u8> = Vec::new();
+        message_bytes.extend("OPENDIME".as_bytes());
+        message_bytes.extend(card_nonce);
+        message_bytes.extend(app_nonce);
+        Message::from_hashed_data::<sha256::Hash>(message_bytes.as_slice())
+    }
+}
+
+impl<T: CkTransport> Debug for TapSigner<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TapSigner")
+            .field("proto", &self.proto)
+            .field("ver", &self.ver)
+            .field("birth", &self.birth)
+            .field("path", &self.path)
+            .field("num_backups", &self.num_backups)
+            .field("pubkey", &self.pubkey)
+            .field("card_nonce", &self.card_nonce)
+            .field("auth_delay", &self.auth_delay)
+            .finish()
+    }
+}
+
+pub struct SatsCard<T: CkTransport> {
     pub transport: T,
     pub secp: Secp256k1<All>,
     pub proto: usize,
@@ -201,7 +178,7 @@ pub struct SatsCard<T: Transport + Sized> {
     pub auth_delay: Option<usize>,
 }
 
-impl<T: Transport> Authentication for SatsCard<T> {
+impl<T: CkTransport> Authentication<T> for SatsCard<T> {
     fn secp(&self) -> &Secp256k1<All> {
         &self.secp
     }
@@ -225,27 +202,35 @@ impl<T: Transport> Authentication for SatsCard<T> {
     fn set_auth_delay(&mut self, auth_delay: Option<usize>) {
         self.auth_delay = auth_delay;
     }
-}
 
-impl<T: Transport> SharedCommands<T> for SatsCard<T> {
     fn transport(&self) -> &T {
         &self.transport
     }
-
-    fn signed_message(&mut self, card_nonce: Vec<u8>, app_nonce: Vec<u8>) -> Vec<u8> {
-        let mut message_bytes: Vec<u8> = Vec::new();
-        message_bytes.extend("OPENDIME".as_bytes());
-        message_bytes.extend(card_nonce);
-        message_bytes.extend(app_nonce);
-        if self.ver != "0.9.0" {
-            let pubkey = self.read().unwrap().pubkey;
-            message_bytes.extend(pubkey);
-        }
-        message_bytes
-    }
 }
 
-impl<T: Transport + Sized> SatsCard<T> {
+impl<T: CkTransport> SatsCard<T> {
+    pub fn from_status(transport: T, status_response: StatusResponse) -> Result<Self, Error> {
+        let pubkey = status_response.pubkey.as_slice(); // TODO verify is 33 bytes?
+        let pubkey = PublicKey::from_slice(pubkey)
+            .map_err(|e| Error::CiborValue(e.to_string()))
+            .unwrap();
+        let slots = status_response
+            .slots
+            .ok_or_else(|| Error::CiborValue("Missing slots".to_string()))?;
+        Ok(Self {
+            transport,
+            secp: Secp256k1::new(),
+            proto: status_response.proto,
+            ver: status_response.ver,
+            birth: status_response.birth,
+            pubkey,
+            card_nonce: status_response.card_nonce,
+            auth_delay: status_response.auth_delay,
+            slots,
+            addr: status_response.addr,
+        })
+    }
+
     pub fn new_slot(
         &mut self,
         slot: usize,
@@ -261,15 +246,6 @@ impl<T: Transport + Sized> SatsCard<T> {
             self.card_nonce = response.card_nonce.clone();
         }
         new_response
-    }
-
-    pub fn read(&mut self) -> Result<ReadResponse, Error> {
-        let command = ReadCommand::for_satscard(self.card_nonce.clone());
-        let response: Result<ReadResponse, Error> = self.transport.transmit(command);
-        if let Ok(read_response) = &response {
-            self.card_nonce = read_response.card_nonce.clone();
-        }
-        response
     }
 
     pub fn derive(&mut self) -> Result<DeriveResponse, Error> {
@@ -311,7 +287,29 @@ impl<T: Transport + Sized> SatsCard<T> {
     }
 }
 
-impl<T: Transport + Sized> Debug for SatsCard<T> {
+impl<T: CkTransport> Wait<T> for SatsCard<T> {}
+
+impl<T: CkTransport> Read<T> for SatsCard<T> {
+    fn requires_auth(&self) -> bool {
+        false
+    }
+}
+
+impl<T: CkTransport> Certificate<T> for SatsCard<T> {
+    fn message_digest(&mut self, card_nonce: Vec<u8>, app_nonce: Vec<u8>) -> Message {
+        let mut message_bytes: Vec<u8> = Vec::new();
+        message_bytes.extend("OPENDIME".as_bytes());
+        message_bytes.extend(card_nonce);
+        message_bytes.extend(app_nonce);
+        if self.ver != "0.9.0" {
+            let pubkey = self.read(None).unwrap().pubkey;
+            message_bytes.extend(pubkey);
+        }
+        Message::from_hashed_data::<sha256::Hash>(message_bytes.as_slice())
+    }
+}
+
+impl<T: CkTransport> Debug for SatsCard<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SatsCard")
             .field("proto", &self.proto)
@@ -323,133 +321,6 @@ impl<T: Transport + Sized> Debug for SatsCard<T> {
             .field("card_nonce", &self.card_nonce)
             .field("auth_delay", &self.auth_delay)
             .finish()
-    }
-}
-
-// card traits
-
-/// Shared commands that are called the same way for all card types.
-pub trait SharedCommands<T>: Authentication
-where
-    T: Transport,
-{
-    fn transport(&self) -> &T;
-    /// The bytes each card signs during authentication
-    fn signed_message(&mut self, card_nonce: Vec<u8>, app_nonce: Vec<u8>) -> Vec<u8>;
-
-    fn wait(&mut self, cvc: Option<String>) -> Result<WaitResponse, Error> {
-        let epubkey_xcvc = cvc.map(|cvc| {
-            let (_, epubkey, xcvc) = self.calc_ekeys_xcvc(cvc, &WaitCommand::name());
-            (epubkey, xcvc)
-        });
-
-        let (epubkey, xcvc) = epubkey_xcvc
-            .map(|(epubkey, xcvc)| (Some(epubkey.serialize().to_vec()), Some(xcvc)))
-            .unwrap_or((None, None));
-
-        let wait_command = WaitCommand::new(epubkey, xcvc);
-        let wait_response: Result<WaitResponse, Error> = self.transport().transmit(wait_command);
-        if let Ok(response) = &wait_response {
-            if response.auth_delay > 0 {
-                self.set_auth_delay(Some(response.auth_delay));
-            } else {
-                self.set_auth_delay(None);
-            }
-        }
-        wait_response
-    }
-
-    fn certs_check(&mut self, nonce: Vec<u8>) -> Result<FactoryRootKey, Error> {
-        let card_nonce = self.card_nonce().clone();
-
-        let certs_cmd = CertsCommand::default();
-        let certs_response: CertsResponse = self.transport().transmit(certs_cmd)?;
-
-        let check_cmd = CheckCommand::new(nonce.clone());
-        let check_response: Result<CheckResponse, Error> = self.transport().transmit(check_cmd);
-        if let Ok(response) = &check_response {
-            self.set_card_nonce(response.card_nonce.clone());
-            // self.card_nonce = response.card_nonce.clone();
-        }
-
-        self.verify_card_signature(check_response.unwrap().auth_sig, card_nonce, nonce)?;
-
-        let mut pubkey = *self.pubkey();
-        for sig in &certs_response.cert_chain() {
-            // BIP-137: https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki
-            let subtract_by = match sig[0] {
-                27..=30 => 27, // P2PKH uncompressed
-                31..=34 => 31, // P2PKH compressed
-                35..=38 => 35, // Segwit P2SH
-                39..=42 => 39, // Segwit Bech32
-                _ => panic!("Unrecognized BIP-137 address"),
-            };
-            let rec_id = RecoveryId::from_i32((sig[0] as i32) - subtract_by).unwrap();
-            let (_, sig) = sig.split_at(1);
-            let rec_sig = RecoverableSignature::from_compact(sig, rec_id).unwrap();
-            let md = Message::from_hashed_data::<sha256::Hash>(&pubkey.serialize());
-            pubkey = self.secp().recover_ecdsa(&md, &rec_sig).unwrap();
-        }
-
-        FactoryRootKey::try_from(pubkey)
-    }
-
-    fn verify_card_signature(
-        &mut self,
-        signature: Vec<u8>,
-        card_nonce: Vec<u8>,
-        app_nonce: Vec<u8>,
-    ) -> Result<(), secp256k1::Error> {
-        let message_bytes = self.signed_message(card_nonce, app_nonce);
-        let message = Message::from_hashed_data::<sha256::Hash>(message_bytes.as_slice());
-        let signature = Signature::from_compact(signature.as_slice())
-            .expect("Failed to construct ECDSA signature from check response");
-
-        self.secp()
-            .verify_ecdsa(&message, &signature, self.pubkey())
-    }
-
-    fn certs(&self) -> Result<CertsResponse, Error> {
-        let certs_command = CertsCommand::default();
-        self.transport().transmit(certs_command)
-    }
-
-    fn nfc(&self) -> Result<NfcResponse, Error> {
-        let nfc_command = NfcCommand::default();
-        self.transport().transmit(nfc_command)
-    }
-}
-
-// Helper functions for authenticated commands.
-pub trait Authentication {
-    fn secp(&self) -> &Secp256k1<All>;
-    fn pubkey(&self) -> &PublicKey;
-    fn card_nonce(&self) -> &Vec<u8>;
-    fn set_card_nonce(&mut self, new_nonce: Vec<u8>);
-    fn auth_delay(&self) -> &Option<usize>;
-    fn set_auth_delay(&mut self, auth_delay: Option<usize>);
-
-    fn calc_ekeys_xcvc(&self, cvc: String, command: &str) -> (SecretKey, PublicKey, Vec<u8>) {
-        let secp = Self::secp(self);
-        let pubkey = Self::pubkey(self);
-        let nonce = Self::card_nonce(self);
-        let cvc_bytes = cvc.as_bytes();
-        let card_nonce_bytes = nonce.as_slice();
-        let card_nonce_command = [card_nonce_bytes, command.as_bytes()].concat();
-        let (eprivkey, epubkey) = secp.generate_keypair(&mut rand::thread_rng());
-        let session_key = SharedSecret::new(pubkey, &eprivkey);
-
-        let md = sha256::Hash::hash(card_nonce_command.as_slice());
-
-        let mask: Vec<u8> = session_key
-            .as_ref()
-            .iter()
-            .zip(md.as_ref())
-            .map(|(x, y)| x ^ y)
-            .take(cvc_bytes.len())
-            .collect();
-        let xcvc = cvc_bytes.iter().zip(mask).map(|(x, y)| x ^ y).collect();
-        (eprivkey, epubkey, xcvc)
     }
 }
 
@@ -466,27 +337,3 @@ pub fn rand_nonce(rng: &mut ThreadRng) -> [u8; 16] {
     rng.fill(&mut nonce);
     nonce
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-
-//     #[test]
-//     fn test_tapsigner_signature() {
-//         let card_pubkey = PublicKey::from_slice(
-//             &from_hex("0335170d9b853440080b0e5d6129f985ebeb919e7a90f28a5fa15c7987ec986a6b")
-//                 .as_slice(),
-//         )
-//         .map_err(|e| Error::CiborValue(e.to_string()))
-//         .unwrap();
-//         let signature: Vec<u8> = from_hex("44721225a42eb3496cc38858adf8fafde9a752776d36c719aaa4f255ab121a0864be7d21eb47a5db88e3879b53ea74794d3e9503cc9b56b8bf9f948324198c30");
-//         let card_nonce: Vec<u8> = from_hex("fd4c5d2c9d9c5a647cbc0b2b79ffef91");
-//         let app_nonce: Vec<u8> = from_hex("273faf8a0b270f697bcb6c90dc8cd4ba");
-//         let secp = Secp256k1::new();
-
-//         assert!(
-//             verify_tapsigner_signature(&card_pubkey, signature, card_nonce, app_nonce, &secp)
-//                 .is_ok()
-//         );
-//     }
-// }

--- a/src/pcsc.rs
+++ b/src/pcsc.rs
@@ -1,119 +1,35 @@
 extern crate core;
 
-use crate::commands::{AppletSelect, CommandApdu, Error, ResponseApdu, StatusResponse};
-use crate::{CkTapCard, SatsCard, TapSigner, Transport};
+use crate::Error;
+use crate::{CkTapCard, CkTransport};
 use pcsc::{Card, Context, Protocols, Scope, ShareMode, MAX_BUFFER_SIZE};
-use secp256k1::{PublicKey, Secp256k1};
 
-pub struct PcscTransport {
-    card: Card,
+pub fn find_first() -> Result<CkTapCard<Card>, Error> {
+    // Establish a PC/SC context.
+    let ctx = Context::establish(Scope::User)?;
+
+    // List available readers.
+    let mut readers_buf = [0; 2048];
+    let mut readers = ctx.list_readers(&mut readers_buf)?;
+
+    // Use the first reader.
+    let reader = match readers.next() {
+        Some(reader) => Ok(reader),
+        None => {
+            //println!("No readers are connected.");
+            Err(Error::PcSc("No readers are connected.".to_string()))
+        }
+    }?;
+    println!("Using reader: {:?}\n", reader);
+
+    ctx.connect(reader, ShareMode::Shared, Protocols::ANY)?
+        .to_cktap()
 }
 
-impl Transport for PcscTransport {
-    fn find_first() -> Result<CkTapCard<Self>, Error> {
-        // Establish a PC/SC context.
-        let ctx = Context::establish(Scope::User)?;
-
-        // List available readers.
-        let mut readers_buf = [0; 2048];
-        let mut readers = ctx.list_readers(&mut readers_buf)?;
-
-        // Use the first reader.
-        let reader = match readers.next() {
-            Some(reader) => Ok(reader),
-            None => {
-                //println!("No readers are connected.");
-                Err(Error::PcSc("No readers are connected.".to_string()))
-            }
-        }?;
-        println!("Using reader: {:?}\n", reader);
-
-        // Connect to the card.
-        let card = ctx.connect(reader, ShareMode::Shared, Protocols::ANY)?;
-
-        // Create transport
-        let transport = Self { card };
-
-        // Get card status
-        let applet_select_apdu = AppletSelect::default().apdu_bytes();
-        let rapdu = transport.transmit_apdu(applet_select_apdu)?;
-        let status_response = StatusResponse::from_cbor(rapdu.to_vec())?;
-
-        // Return correct card variant
-        match (status_response.tapsigner, status_response.satschip) {
-            (Some(true), None) => Ok(CkTapCard::TapSigner(TapSigner::from_status(
-                transport,
-                status_response,
-            ))),
-            (Some(true), Some(true)) => {
-                // // get common fields - moving to Constructors
-                let secp = Secp256k1::new();
-                let proto = status_response.proto;
-                let ver = status_response.ver;
-                let birth = status_response.birth;
-                let pubkey = status_response.pubkey.as_slice(); // TODO verify is 33 bytes?
-                let pubkey =
-                    PublicKey::from_slice(pubkey).map_err(|e| Error::CiborValue(e.to_string()))?;
-                let card_nonce = status_response.card_nonce;
-                let auth_delay = status_response.auth_delay;
-
-                let path = status_response.path;
-                let num_backups = status_response.num_backups;
-
-                Ok(CkTapCard::SatsChip(TapSigner {
-                    transport,
-                    secp,
-                    proto,
-                    ver,
-                    birth,
-                    path,
-                    num_backups,
-                    pubkey,
-                    card_nonce,
-                    auth_delay,
-                }))
-            }
-            (None, None) => {
-                // // get common fields - moving to Constructors
-                let secp = Secp256k1::new();
-                let proto = status_response.proto;
-                let ver = status_response.ver;
-                let birth = status_response.birth;
-                let pubkey = status_response.pubkey.as_slice(); // TODO verify is 33 bytes?
-                let pubkey =
-                    PublicKey::from_slice(pubkey).map_err(|e| Error::CiborValue(e.to_string()))?;
-                let card_nonce = status_response.card_nonce;
-                let auth_delay = status_response.auth_delay;
-
-                let slots = status_response
-                    .slots
-                    .ok_or_else(|| Error::CiborValue("Missing slots".to_string()))?;
-
-                let addr = status_response.addr;
-
-                Ok(CkTapCard::SatsCard(SatsCard {
-                    transport,
-                    secp,
-                    proto,
-                    ver,
-                    birth,
-                    slots,
-                    addr,
-                    pubkey,
-                    card_nonce,
-                    auth_delay,
-                }))
-            }
-            (_, _) => {
-                // TODO throw error
-                todo!()
-            }
-        }
-    }
-
+impl CkTransport for Card {
     fn transmit_apdu(&self, apdu: Vec<u8>) -> Result<Vec<u8>, Error> {
         let mut receive_buffer = vec![0; MAX_BUFFER_SIZE];
-        let rapdu = self.card.transmit(apdu.as_slice(), &mut receive_buffer)?;
+        let rapdu = self.transmit(apdu.as_slice(), &mut receive_buffer)?;
         Ok(rapdu.to_vec())
     }
 }


### PR DESCRIPTION
### Description

- Breaking apart SharedCommands trait to encapsulate command logic and improve card composability
- Defined trait commands into commands.rs and moved command/response apdu into adpu.rs  
- New as_cktap function in Transport trait + impl Transport on pcsc Card
 
### Notes to the reviewers

Just read the CONTRIBUTING.md. I'll be more mindful of it moving forward, but hopefully it's not too much of an issue this time around.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [x] I _read_ the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
