### PR TITLE
Cli framework with minimal functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,12 @@ secp256k1 = { version = "0.26.0", features = ["rand-std", "bitcoin-hashes-std", 
 
 # optional dependencies
 pcsc = { version = "2", optional = true }
+clap = { version = "4.3.1", features = ["derive"] }
 
 [[example]]
 name = "pcsc"
+required-features = ["pcsc"]
+
+[[bin]]
+name = "cktap-cli"
 required-features = ["pcsc"]

--- a/examples/pcsc.rs
+++ b/examples/pcsc.rs
@@ -6,7 +6,6 @@ use rust_cktap::commands::{
     // Read,
     Wait,
 };
-use rust_cktap::rand_nonce;
 use rust_cktap::{pcsc, rand_chaincode, CkTapCard};
 
 use secp256k1::rand;
@@ -48,8 +47,7 @@ fn main() -> Result<(), Error> {
             // let read_result = card.read(cvc.clone())?;
             // dbg!(read_result);
 
-            let nonce = rand_nonce(rng);
-            dbg!(ts.check_certificate(nonce.to_vec()).unwrap().name());
+            dbg!(ts.check_certificate().unwrap().name());
 
             //let dump_result = card.dump();
 
@@ -96,8 +94,7 @@ fn main() -> Result<(), Error> {
             // let derive_result = card.derive()?;
             // dbg!(&derive_result);
 
-            let nonce = rand_nonce(rng);
-            dbg!(sc.check_certificate(nonce.to_vec()).unwrap().name());
+            dbg!(sc.check_certificate().unwrap().name());
 
             // let nfc_result = card.nfc()?;
             // dbg!(nfc_result);

--- a/src/bin/cktap-cli.rs
+++ b/src/bin/cktap-cli.rs
@@ -1,0 +1,66 @@
+/// CLI for rust-cktap
+use clap::{Parser, Subcommand};
+use rust_cktap::{apdu::Error, commands::Certificate, pcsc, CkTapCard};
+use std::io;
+use std::io::Write;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Check this card was made by Coinkite: Verifies a certificate chain up to root factory key.
+    Certs,
+    /// Get website URL used for NFC verification, and optionally open it
+    Url,
+}
+
+fn main() -> Result<(), Error> {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Certs => {
+            let card = pcsc::find_first()?;
+            fn print_genuine(key: String) {
+                println!("Genuine card from Coinkite.\n\nHas cert signed by: {}", key);
+            }
+            fn print_failure() {
+                println!("Card failed to verify. May not be a genuine card");
+            }
+            match card {
+                CkTapCard::TapSigner(mut ts) => match ts.check_certificate() {
+                    Ok(key) => print_genuine(key.name()),
+                    Err(_e) => print_failure(),
+                },
+                CkTapCard::SatsChip(_chip) => todo!(),
+                CkTapCard::SatsCard(mut sc) => match sc.check_certificate() {
+                    Ok(key) => print_genuine(key.name()),
+                    Err(_e) => print_failure(),
+                },
+            }
+        }
+        Commands::Url => {
+            let card = pcsc::find_first()?;
+            match card {
+                CkTapCard::TapSigner(mut _ts) => todo!(),
+                CkTapCard::SatsChip(mut _chip) => todo!(),
+                CkTapCard::SatsCard(mut _sc) => todo!(),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn _get_cvc() -> String {
+    print!("Enter cvc: ");
+    io::stdout().flush().unwrap();
+    let mut cvc: String = String::new();
+    let _btye_count = std::io::stdin().read_line(&mut cvc).unwrap();
+    cvc.trim().to_string()
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,5 @@
-use crate::apdu::*;
 use crate::factory_root_key::FactoryRootKey;
+use crate::{apdu::*, rand_nonce};
 use crate::{CkTapCard, SatsCard, TapSigner};
 
 use secp256k1::ecdh::SharedSecret;
@@ -136,7 +136,10 @@ where
 {
     fn message_digest(&mut self, card_nonce: Vec<u8>, app_nonce: Vec<u8>) -> Message;
 
-    fn check_certificate(&mut self, nonce: Vec<u8>) -> Result<FactoryRootKey, Error> {
+    fn check_certificate(&mut self) -> Result<FactoryRootKey, Error> {
+        let rng = &mut rand::thread_rng();
+        let nonce = rand_nonce(rng).to_vec();
+
         let card_nonce = self.card_nonce().clone();
 
         let certs_cmd = CertsCommand::default();

--- a/src/pcsc.rs
+++ b/src/pcsc.rs
@@ -20,7 +20,6 @@ pub fn find_first() -> Result<CkTapCard<Card>, Error> {
             Err(Error::PcSc("No readers are connected.".to_string()))
         }
     }?;
-    println!("Using reader: {:?}\n", reader);
 
     ctx.connect(reader, ShareMode::Shared, Protocols::ANY)?
         .to_cktap()


### PR DESCRIPTION
### Description

Framework for the cli tool using clap as described in https://github.com/notmandatory/rust-cktap/issues/11

### Notes to the reviewers

- As it stands, there's a lot of nesting and redundancy. Looking for ways to minimize this without introducing cli logic into the lib. 
- Leaving examples/pcsc for now as a reference for calling lib interface.

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
