### PR TITLE
Read response verification

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,6 +18,8 @@ struct SatsCardCli {
 /// Commands supported by SatsCard cards
 #[derive(Subcommand)]
 enum SatsCardCommand {
+    /// Show the card status
+    Debug,
     /// Show current deposit address
     Address,
     /// Check this card was made by Coinkite: Verifies a certificate chain up to root factory key.
@@ -38,6 +40,8 @@ struct TapSignerCli {
 /// Commands supported by TapSigner cards
 #[derive(Subcommand)]
 enum TapSignerCommand {
+    /// Show the card status
+    Debug,
     /// Check this card was made by Coinkite: Verifies a certificate chain up to root factory key.
     Certs,
     /// Read the pubkey (requires CVC)
@@ -47,11 +51,14 @@ enum TapSignerCommand {
 fn main() -> Result<(), Error> {
     // figure out what type of card we have before parsing cli args
     let mut card = pcsc::find_first()?;
-    
+
     match &mut card {
         CkTapCard::SatsCard(sc) => {
             let cli = SatsCardCli::parse();
             match cli.command {
+                SatsCardCommand::Debug => {
+                    dbg!(&sc);
+                }
                 SatsCardCommand::Address => println!("Address: {}", sc.address().unwrap()),
                 SatsCardCommand::Certs => check_cert(sc),
                 SatsCardCommand::Read => read(sc, None),
@@ -60,6 +67,9 @@ fn main() -> Result<(), Error> {
         CkTapCard::TapSigner(ts) | CkTapCard::SatsChip(ts) => {
             let cli = TapSignerCli::parse();
             match cli.command {
+                TapSignerCommand::Debug => {
+                    dbg!(&ts);
+                }
                 TapSignerCommand::Certs => check_cert(ts),
                 TapSignerCommand::Read => read(ts, Some(cvc())),
             }
@@ -88,7 +98,7 @@ fn read<T: CkTransport>(card: &mut dyn Read<T>, cvc: Option<String>) {
         Err(e) => {
             dbg!(&e);
             println!("Failed to read with error: ")
-        },
+        }
     }
 }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,6 +13,7 @@ secp256k1 = { version = "0.26.0", features = ["rand-std", "bitcoin-hashes-std", 
 
 # optional dependencies
 pcsc = { version = "2", optional = true }
+# bech32 = "0.9.1"
 
 [[example]]
 name = "pcsc"

--- a/lib/src/apdu.rs
+++ b/lib/src/apdu.rs
@@ -10,8 +10,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 
-use crate::commands::Authentication;
-
 pub const APP_ID: [u8; 15] = *b"\xf0CoinkiteCARDv1";
 pub const SELECT_CLA_INS_P1P2: [u8; 4] = [0x00, 0xA4, 0x04, 0x00];
 pub const CBOR_CLA_INS_P1P2: [u8; 4] = [0x00, 0xCB, 0x00, 0x00];
@@ -243,12 +241,6 @@ impl Debug for ReadResponse {
             .finish()
     }
 }
-
-// impl ReadResponse {
-//     pub fn pubkey(&self) -> PublicKey {
-//         PublicKey::from_slice(self.pubkey.as_slice()).unwrap()
-//     }
-// }
 
 // Checks payment address derivation: https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#satscard-checks-payment-address-derivation
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]

--- a/lib/src/apdu.rs
+++ b/lib/src/apdu.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 
+use crate::commands::Authentication;
+
 pub const APP_ID: [u8; 15] = *b"\xf0CoinkiteCARDv1";
 pub const SELECT_CLA_INS_P1P2: [u8; 4] = [0x00, 0xA4, 0x04, 0x00];
 pub const CBOR_CLA_INS_P1P2: [u8; 4] = [0x00, 0xCB, 0x00, 0x00];
@@ -225,6 +227,12 @@ pub struct ReadResponse {
 }
 
 impl ResponseApdu for ReadResponse {}
+
+impl fmt::Display for ReadResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "pubkey: {}", self.pubkey.to_hex())
+    }
+}
 
 impl Debug for ReadResponse {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -4,6 +4,7 @@ use secp256k1::rand::Rng;
 use secp256k1::{All, Message, PublicKey, Secp256k1};
 use std::fmt;
 use std::fmt::Debug;
+// use bech32::{self, FromBase32, ToBase32, Variant};
 
 pub mod apdu;
 pub mod commands;
@@ -137,6 +138,10 @@ impl<T: CkTransport> Wait<T> for TapSigner<T> {}
 impl<T: CkTransport> Read<T> for TapSigner<T> {
     fn requires_auth(&self) -> bool {
         true
+    }
+
+    fn slot(&self) -> Option<u8> {
+        None
     }
 }
 
@@ -285,6 +290,17 @@ impl<T: CkTransport> SatsCard<T> {
         let dump_command = DumpCommand::new(slot, epubkey, xcvc);
         self.transport.transmit(dump_command)
     }
+
+    pub fn address(&mut self) -> Result<String, Error> {
+        // let pubkey = self.read(None).unwrap().pubkey;
+        // // let hrp = match self.testnet() { }
+        // let encoded = bech32::encode("bc", pubkey.to_base32(), Variant::Bech32);
+        // match encoded {
+        //     Ok(e) => Ok(e),
+        //     Err(_) => panic!("Failed to encoded pubkey")
+        // }
+        todo!()
+    }
 }
 
 impl<T: CkTransport> Wait<T> for SatsCard<T> {}
@@ -292,6 +308,9 @@ impl<T: CkTransport> Wait<T> for SatsCard<T> {}
 impl<T: CkTransport> Read<T> for SatsCard<T> {
     fn requires_auth(&self) -> bool {
         false
+    }
+    fn slot(&self) -> Option<u8> {
+        Some(self.slots.0 as u8)
     }
 }
 


### PR DESCRIPTION
### Description

Validate the signature of the ReadResponse against the signature as described in https://github.com/notmandatory/rust-cktap/issues/6. For Satscard, public key is for active slot. For Tapsigner, the "pubkey" provided in the response must be unzipped (XORed) to get the public key for the current derivation path. 

### Notes to the reviewers

- Rather than changing the `calc_ekeys_xcvc` interface, the session_key is being recalculated outside.
- I created a standalone `unzip` function that might be better off as a trait implement by a Vec<u8> pubkey, so there may be a follow up commit time-permitting.
- I added a `debug` command to the cli for developer convenience, but can remove if needed

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
