### PR TITLE
Add derive to cli, verify_sig function

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,6 +26,8 @@ enum SatsCardCommand {
     Certs,
     /// Read the pubkey
     Read,
+    /// Derive a public key at the m/0 path, the first non-hardened derived key
+    Derive,
 }
 
 /// TapSigner CLI
@@ -46,6 +48,12 @@ enum TapSignerCommand {
     Certs,
     /// Read the pubkey (requires CVC)
     Read,
+    /// Derive a public key at the given hardened path
+    Derive {
+        /// path, eg. for 84'/0'/0'/* use 84,0,0
+        #[clap(short, long, value_delimiter = ',', num_args = 1..)]
+        path: Vec<u32>,
+    },
 }
 
 fn main() -> Result<(), Error> {
@@ -62,6 +70,10 @@ fn main() -> Result<(), Error> {
                 SatsCardCommand::Address => println!("Address: {}", sc.address().unwrap()),
                 SatsCardCommand::Certs => check_cert(sc),
                 SatsCardCommand::Read => read(sc, None),
+                SatsCardCommand::Derive => {
+                    let response = &sc.derive();
+                    dbg!(response);
+                }
             }
         }
         CkTapCard::TapSigner(ts) | CkTapCard::SatsChip(ts) => {
@@ -72,6 +84,10 @@ fn main() -> Result<(), Error> {
                 }
                 TapSignerCommand::Certs => check_cert(ts),
                 TapSignerCommand::Read => read(ts, Some(cvc())),
+                TapSignerCommand::Derive { path } => {
+                    let response = &ts.derive(path, cvc());
+                    dbg!(response);
+                }
             }
         }
     }


### PR DESCRIPTION
### Description

Add `derive` commands to cli, refactor the signature verification code into `verify_sig` function.

### Notes to the reviewers

For some reason the `verify_sig` function isn't working for the `derive` command, I couldn't find an example in the python `cktap` CLI so I sent an email @doc-hex for advice. 

### Changelog notice

- Add derive CLI command

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
