### PR TITLE
Derive verification

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,6 +59,12 @@ enum TapSignerCommand {
     Read,
     /// This command is used once to initialize a new card.
     Init,
+    /// Derive a public key at the given hardened path
+    Derive {
+        /// path, eg. for 84'/0'/0'/* use 84,0,0
+        #[clap(short, long, value_delimiter = ',', num_args = 1..)]
+        path: Vec<u32>,
+    },
 }
 
 fn main() -> Result<(), Error> {
@@ -93,9 +99,9 @@ fn main() -> Result<(), Error> {
                     let response = &sc.unseal(slot, cvc());
                     dbg!(response);
                 }
-                SatsCardCommand::Derive => { 
-                    dbg!(sc.derive());
-                },
+                SatsCardCommand::Derive => {
+                    dbg!(&sc.derive());
+                }
             }
         }
         CkTapCard::TapSigner(ts) | CkTapCard::SatsChip(ts) => {
@@ -110,6 +116,9 @@ fn main() -> Result<(), Error> {
                     let chain_code = rand_chaincode(rng).to_vec();
                     let response = &ts.init(chain_code, cvc());
                     dbg!(response);
+                }
+                TapSignerCommand::Derive { path } => {
+                    dbg!(&ts.derive(path, cvc()));
                 }
             }
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -35,6 +35,8 @@ enum SatsCardCommand {
     New,
     /// Unseal the current slot.
     Unseal,
+    /// Get the payment address and verify it follows from the chain code and master public key
+    Derive,
 }
 
 /// TapSigner CLI
@@ -91,6 +93,9 @@ fn main() -> Result<(), Error> {
                     let response = &sc.unseal(slot, cvc());
                     dbg!(response);
                 }
+                SatsCardCommand::Derive => { 
+                    dbg!(sc.derive());
+                },
             }
         }
         CkTapCard::TapSigner(ts) | CkTapCard::SatsChip(ts) => {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,7 +10,6 @@ ciborium = "0.2.0"
 serde = "1"
 serde_bytes = "0.11"
 secp256k1 = { version = "0.26.0", features = ["rand-std", "bitcoin-hashes-std", "recovery"] }
-bitcoin = "0.30.0"
 
 # optional dependencies
 pcsc = { version = "2", optional = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,6 +10,7 @@ ciborium = "0.2.0"
 serde = "1"
 serde_bytes = "0.11"
 secp256k1 = { version = "0.26.0", features = ["rand-std", "bitcoin-hashes-std", "recovery"] }
+bitcoin = "0.30.0"
 
 # optional dependencies
 pcsc = { version = "2", optional = true }

--- a/lib/src/apdu.rs
+++ b/lib/src/apdu.rs
@@ -251,9 +251,12 @@ pub struct DeriveCommand {
     /// provided by app, cannot be all same byte (& should be random), 16 bytes
     #[serde(with = "serde_bytes")]
     nonce: Vec<u8>,
+    /// # Tapsigner: derivation path, can be empty list for `m` case (a no-op)
     path: Option<Vec<usize>>,
+    /// app's ephemeral public key
     #[serde(with = "serde_bytes")]
     epubkey: Option<Vec<u8>>,
+    /// encrypted CVC value
     #[serde(with = "serde_bytes")]
     xcvc: Option<Vec<u8>>,
 }

--- a/lib/src/commands.rs
+++ b/lib/src/commands.rs
@@ -225,6 +225,13 @@ where
     }
 }
 
+// pub trait Derive<T>: Authentication<T>
+// where
+//     T: CkTransport,
+// {
+    
+// }
+
 fn unzip(encoded: &mut Vec<u8>, session_key: SharedSecret) -> Result<PublicKey, secp256k1::Error> {
     let session_key = session_key.as_ref(); // 32 bytes
     let mut pubkey = encoded.clone();


### PR DESCRIPTION
### Description

DeriveResponse verification for Satscard and Tapsigner 

### Notes to the reviewers

There is additional logic to be done on top of the DeriveResponse as described in the protocol docs. The approach to this is commented out but may be useful later. For now, I just want to get the Signature verification merged, since I'm not sure how much time I'll have in the near future and don't want to leave the branch hanging.

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature


