### PR TITLE
[fix] tapsigner init needs to add entropy

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,7 +102,7 @@ fn main() -> Result<(), Error> {
                 TapSignerCommand::Certs => check_cert(ts),
                 TapSignerCommand::Read => read(ts, Some(cvc())),
                 TapSignerCommand::Init => {
-                    let chain_code = Some(rand_chaincode(rng).to_vec());
+                    let chain_code = rand_chaincode(rng).to_vec();
                     let response = &ts.init(chain_code, cvc());
                     dbg!(response);
                 }

--- a/lib/examples/pcsc.rs
+++ b/lib/examples/pcsc.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Error> {
             // only do this once per card!
             if ts.path.is_none() {
                 let chain_code = rand_chaincode(rng).to_vec();
-                let new_result = ts.init(Some(chain_code), cvc)?;
+                let new_result = ts.init(chain_code, cvc)?;
                 dbg!(new_result);
             }
 
@@ -66,7 +66,7 @@ fn main() -> Result<(), Error> {
             // only do this once per card!
             if chip.path.is_none() {
                 let chain_code = rand_chaincode(rng).to_vec();
-                let new_result = chip.init(Some(chain_code), get_cvc())?;
+                let new_result = chip.init(chain_code, get_cvc())?;
                 dbg!(new_result);
             }
 

--- a/lib/src/commands.rs
+++ b/lib/src/commands.rs
@@ -249,7 +249,7 @@ mod tests {
     #[test]
     fn test_new_command() {
         let rng = &mut rand::thread_rng();
-        let chain_code = Some(rand_chaincode(rng).to_vec());
+        let chain_code = rand_chaincode(rng).to_vec();
 
         let emulator = find_emulator().unwrap();
         match emulator {
@@ -257,7 +257,14 @@ mod tests {
                 let current_slot = sc.slots.0;
                 let response = sc.unseal(current_slot, CVC.to_string());
                 assert!(response.is_ok());
-                let response = sc.new_slot(current_slot + 1, chain_code, CVC.to_string());
+                let response = sc.new_slot(current_slot + 1, Some(chain_code), CVC.to_string());
+                assert!(response.is_ok());
+                assert_eq!(sc.slots.0, current_slot + 1);
+                // test with no new chain_code
+                let current_slot = sc.slots.0;
+                let response = sc.unseal(current_slot, CVC.to_string());
+                assert!(response.is_ok());
+                let response = sc.new_slot(current_slot + 1, None, CVC.to_string());
                 assert!(response.is_ok());
                 assert_eq!(sc.slots.0, current_slot + 1);
             }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -107,10 +107,10 @@ impl<T: CkTransport> TapSigner<T> {
         }
     }
 
-    pub fn init(&mut self, chain_code: Option<Vec<u8>>, cvc: String) -> Result<NewResponse, Error> {
+    pub fn init(&mut self, chain_code: Vec<u8>, cvc: String) -> Result<NewResponse, Error> {
         let (_, epubkey, xcvc) = self.calc_ekeys_xcvc(cvc, &NewCommand::name());
         let epubkey = epubkey.serialize().to_vec();
-        let new_command = NewCommand::new(Some(0), chain_code, epubkey, xcvc);
+        let new_command = NewCommand::new(Some(0), Some(chain_code), epubkey, xcvc);
         let new_response: Result<NewResponse, Error> = self.transport.transmit(new_command);
         if let Ok(response) = &new_response {
             self.card_nonce = response.card_nonce.clone();


### PR DESCRIPTION
### Description

Oops, this PR fixes #21 the TapSigner `init` function to require added entropy.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
