### PR TITLE
Adding command for tapsigner command for change cvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # rust-cktap
 
-[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/notmandatory/rust-cktap/blob/master/LICENSE) 
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/notmandatory/rust-cktap/blob/master/LICENSE)
 [![CI](https://github.com/notmandatory/rust-cktap/actions/workflows/test.yml/badge.svg)](https://github.com/notmandatory/rust-cktap/actions/workflows/test.yml)
 [![rustc](https://img.shields.io/badge/rustc-1.57.0%2B-lightgrey.svg)](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html)
 
 A Rust implementation of the [Coinkite Tap Protocol](https://github.com/coinkite/coinkite-tap-proto) (cktap)
 for use with [SATSCARD], [TAPSIGNER], and [SATSCHIP] products.
 
-This project provides PC/SC APDU message encoding and decoding, cvc authentication, certificate chain verification, and card response verification. 
+This project provides PC/SC APDU message encoding and decoding, cvc authentication, certificate chain verification, and card response verification.
 
 It is up to the crate user to send and receive the raw cktap APDU messages via NFC to the card by implementing the `CkTransport` trait. An example implementation is provided using the optional rust `pcsc` crate. Mobile users are expected to implement `CkTransport` using the iOS or Android provided libraries.
 
@@ -37,7 +37,7 @@ It is up to the crate user to send and receive the raw cktap APDU messages via N
 
 #### TAPSIGNER-Only Commands
 
-- [ ] [change](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#change)
+- [x] [change](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#change)
 - [x] [xpub](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#xpub)
 - [ ] [backup](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#backup)
 
@@ -52,13 +52,13 @@ It is up to the crate user to send and receive the raw cktap APDU messages via N
 
 #### Prerequisites
 
-1. USB PCSC NFC card reader, for example:  
+1. USB PCSC NFC card reader, for example:
    * [OMNIKEY 5022 CL](https://www.hidglobal.com/products/omnikey-5022-reader)
 2. Coinkite SATSCARD, TAPSIGNER, or SATSCHIP cards
 Install vendor PCSC driver
 3. Connect NFC reader to desktop system
 4. Place SATSCARD, TAPSIGNER, or SATSCHIP on reader
- 
+
 #### Run CLI
 
    ```

--- a/lib/src/apdu.rs
+++ b/lib/src/apdu.rs
@@ -918,3 +918,50 @@ impl Debug for XpubResponse {
             .finish()
     }
 }
+
+/// TAPSIGNER only - Change the CVC of the card.  Changes from the value on the card.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct ChangeCVCCommand {
+    cmd: String, // "change"
+    #[serde(with = "serde_bytes")]
+    data: Vec<u8>, // new CVC, encrypted
+    #[serde(with = "serde_bytes")]
+    epubkey: Vec<u8>, // app's ephemeral public key (required)
+    #[serde(with = "serde_bytes")]
+    xcvc: Vec<u8>, //encrypted CVC value (required)
+}
+
+impl CommandApdu for ChangeCVCCommand {
+    fn name() -> String {
+        "change".to_string()
+    }
+}
+
+impl ChangeCVCCommand {
+    pub fn new(data: Vec<u8>, epubkey: PublicKey, xcvc: Vec<u8>) -> Self {
+        Self {
+            cmd: Self::name(),
+            data,
+            epubkey: epubkey.serialize().to_vec(),
+            xcvc,
+        }
+    }
+}
+
+#[derive(Deserialize, Clone)]
+pub struct ChangeCVCResponse {
+    pub success: bool,
+    #[serde(with = "serde_bytes")]
+    pub card_nonce: Vec<u8>,
+}
+
+impl ResponseApdu for ChangeCVCResponse {}
+
+impl Debug for ChangeCVCResponse {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("ChangeCVCResponse")
+            .field("success", &self.success)
+            .field("card_nonce", &self.card_nonce.to_hex())
+            .finish()
+    }
+}


### PR DESCRIPTION
### Description

Tapsigner 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Tapsigner command called `change`.  This command changes the cvc value of the card.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
