### PR TITLE
(draft)fix: swift bindings ffi setup

### DIFF
--- a/cktap-swift/build-xcframework.sh
+++ b/cktap-swift/build-xcframework.sh
@@ -28,20 +28,20 @@ cd ../ || exit
 
 # Target architectures
 # macOS Intel
-cargo build --package rust-cktap --profile release-smaller --target x86_64-apple-darwin
+cargo build --package rust-cktap --profile release-smaller --target x86_64-apple-darwin --features uniffi
 # macOS Apple Silicon
-cargo build --package rust-cktap --profile release-smaller --target aarch64-apple-darwin
+cargo build --package rust-cktap --profile release-smaller --target aarch64-apple-darwin --features uniffi
 # Simulator on Intel Macs
-cargo build --package rust-cktap --profile release-smaller --target x86_64-apple-ios
+cargo build --package rust-cktap --profile release-smaller --target x86_64-apple-ios --features uniffi
 # Simulator on Apple Silicon Mac
-cargo build --package rust-cktap --profile release-smaller --target aarch64-apple-ios-sim
+cargo build --package rust-cktap --profile release-smaller --target aarch64-apple-ios-sim --features uniffi
 # iPhone devices
-cargo build --package rust-cktap --profile release-smaller --target aarch64-apple-ios
+cargo build --package rust-cktap --profile release-smaller --target aarch64-apple-ios --features uniffi
 
 # Then run uniffi-bindgen
 cargo run --bin uniffi-bindgen generate \
     --features uniffi \
-    --library target/aarch64-apple-ios/release-smaller/librust_cktap.dylib \
+    --manifest-path ../lib/Cargo.toml \
     --language swift \
     --out-dir cktap-swift/Sources/CKTap \
     --no-format
@@ -53,10 +53,6 @@ lipo target/aarch64-apple-ios-sim/release-smaller/librust_cktap.a target/x86_64-
 lipo target/aarch64-apple-darwin/release-smaller/librust_cktap.a target/x86_64-apple-darwin/release-smaller/librust_cktap.a -create -output target/lipo-macos/release-smaller/librust_cktap.a
 
 cd cktap-swift || exit
-
-# move cktap-ffi static lib header files to temporary directory
-mv "Sources/CKTap/rust_cktapFFI.h" "${NEW_HEADER_DIR}"
-mv "Sources/CKTap/rust_cktapFFI.modulemap" "${NEW_HEADER_DIR}/module.modulemap"
 
 # remove old xcframework directory
 rm -rf "${OUTDIR}/${NAME}.xcframework"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

A bunch of changes since #25 that were awesome but swift bindings needed to catch up to them.

#28 solved getting framework to build.

This PR hopefully solves making the framework usable in iOS app again and clean up any unnecessary lines of code.

Tested in iOS app project

<img width="1400" alt="Screenshot 2025-05-01 at 10 19 00 AM" src="https://github.com/user-attachments/assets/ff98f9da-2984-4bc4-866a-7251e99a57e3" />

### Notes to the reviewers

**Add --features uniffi to cargo build commands**: 
Enables the uniffi feature during compilation of each static library to ensure the necessary FFI shim functions defined via #[uniffi::export] are included, fixing linker errors.

**Use --manifest-path in uniffi-bindgen**: 
Generates Swift bindings directly from the Rust crate's Cargo.toml and source code, instead of inspecting a pre-compiled library artifact.

**Remove mv commands for headers**: 
Deletes outdated commands that failed because they tried to move header files based on the previous .udl setup, which are no longer needed as xcodebuild finds the headers correctly elsewhere.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
