### PR TITLE
chore: remove unneeded uniffi feature

### DIFF
--- a/cktap-ffi/Cargo.toml
+++ b/cktap-ffi/Cargo.toml
@@ -10,12 +10,8 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 rust-cktap = { path = "../lib" }
-uniffi = { version = "0.29", features = ["cli"], optional = true }
+uniffi = { version = "0.29", features = ["cli"] }
 thiserror = "1.0"
-
-[build-dependencies]
-uniffi = { version = "0.29", features = ["build"], optional = true }
 
 [features]
 default = []
-uniffi = ["dep:uniffi"] 

--- a/cktap-ffi/src/bin/uniffi-bindgen.rs
+++ b/cktap-ffi/src/bin/uniffi-bindgen.rs
@@ -1,4 +1,3 @@
 fn main() {
-    #[cfg(feature = "uniffi")]
     uniffi::uniffi_bindgen_main()
 }

--- a/cktap-ffi/src/lib.rs
+++ b/cktap-ffi/src/lib.rs
@@ -1,11 +1,9 @@
-#[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
 use rust_cktap::apdu::{AppletSelect, CommandApdu, ResponseApdu, StatusResponse};
 use rust_cktap::{rand_nonce as core_rand_nonce, Error as CoreError};
 use std::fmt::Debug;
 
-#[cfg(feature = "uniffi")]
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum Error {
     #[error("Core Error: {msg}")]
@@ -14,14 +12,12 @@ pub enum Error {
     Transport { msg: String },
 }
 
-#[cfg(feature = "uniffi")]
 impl From<CoreError> for Error {
     fn from(e: CoreError) -> Self {
         Error::Core { msg: e.to_string() }
     }
 }
 
-#[cfg(feature = "uniffi")]
 #[derive(uniffi::Record)]
 pub struct FfiStatusResponse {
     pub proto: u64,
@@ -41,7 +37,6 @@ pub struct FfiStatusResponse {
     pub auth_delay: Option<u64>,
 }
 
-#[cfg(feature = "uniffi")]
 impl From<StatusResponse> for FfiStatusResponse {
     fn from(sr: StatusResponse) -> Self {
         Self {
@@ -63,13 +58,11 @@ impl From<StatusResponse> for FfiStatusResponse {
     }
 }
 
-#[cfg(feature = "uniffi")]
 #[uniffi::export(callback_interface)]
 pub trait CkTransportFfi: Send + Sync + Debug + 'static {
     fn transmit_apdu(&self, command_apdu: Vec<u8>) -> Result<Vec<u8>, Error>;
 }
 
-#[cfg(feature = "uniffi")]
 #[uniffi::export]
 pub async fn get_status(transport: Box<dyn CkTransportFfi>) -> Result<FfiStatusResponse, Error> {
     let cmd = AppletSelect::default();
@@ -81,7 +74,6 @@ pub async fn get_status(transport: Box<dyn CkTransportFfi>) -> Result<FfiStatusR
     Ok(response.into())
 }
 
-#[cfg(feature = "uniffi")]
 #[derive(uniffi::Record)]
 pub struct TestRecord {
     pub message: String,
@@ -89,13 +81,11 @@ pub struct TestRecord {
 }
 
 // this is actually a class per Object not Record
-#[cfg(feature = "uniffi")]
 #[derive(uniffi::Object)]
 pub struct TestStruct {
     pub value: u32,
 }
 
-#[cfg(feature = "uniffi")]
 #[uniffi::export]
 pub fn rand_nonce() -> Vec<u8> {
     core_rand_nonce().to_vec()

--- a/cktap-swift/build-xcframework.sh
+++ b/cktap-swift/build-xcframework.sh
@@ -38,18 +38,18 @@ cd ../ || exit
 
 # Target architectures
 # macOS Intel
-cargo build --package ${FFI_PKG_NAME} --features uniffi --profile ${RELDIR} --target x86_64-apple-darwin
+cargo build --package ${FFI_PKG_NAME} --profile ${RELDIR} --target x86_64-apple-darwin
 # macOS Apple Silicon
-cargo build --package ${FFI_PKG_NAME} --features uniffi --profile ${RELDIR} --target aarch64-apple-darwin
+cargo build --package ${FFI_PKG_NAME} --profile ${RELDIR} --target aarch64-apple-darwin
 # Simulator on Intel Macs
-cargo build --package ${FFI_PKG_NAME} --features uniffi --profile ${RELDIR} --target x86_64-apple-ios
+cargo build --package ${FFI_PKG_NAME} --profile ${RELDIR} --target x86_64-apple-ios
 # Simulator on Apple Silicon Mac
-cargo build --package ${FFI_PKG_NAME} --features uniffi --profile ${RELDIR} --target aarch64-apple-ios-sim
+cargo build --package ${FFI_PKG_NAME} --profile ${RELDIR} --target aarch64-apple-ios-sim
 # iPhone devices
-cargo build --package ${FFI_PKG_NAME} --features uniffi --profile ${RELDIR} --target aarch64-apple-ios
+cargo build --package ${FFI_PKG_NAME} --profile ${RELDIR} --target aarch64-apple-ios
 
 # Then run uniffi-bindgen
-cargo run --package ${FFI_PKG_NAME} --bin uniffi-bindgen --features uniffi generate \
+cargo run --package ${FFI_PKG_NAME} --bin uniffi-bindgen generate \
     --library target/aarch64-apple-ios/${RELDIR}/${DYLIB_FILENAME} \
     --language swift \
     --out-dir cktap-swift/Sources/CKTap \


### PR DESCRIPTION
### Description

Since #34 we don't need a feature flag for uniffi. It should always be enabled when building the cktap-ffi package.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
