### PR TITLE
chore: fix clippy::uninlined_format_args

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -100,12 +100,12 @@ async fn main() -> Result<(), Error> {
                     let slot = sc.slot().expect("current slot number");
                     let chain_code = Some(rand_chaincode(rng));
                     let response = &sc.new_slot(slot, chain_code, &cvc()).await.unwrap();
-                    println!("{}", response)
+                    println!("{response}")
                 }
                 SatsCardCommand::Unseal => {
                     let slot = sc.slot().expect("current slot number");
                     let response = &sc.unseal(slot, &cvc()).await.unwrap();
-                    println!("{}", response)
+                    println!("{response}")
                 }
                 SatsCardCommand::Derive => {
                     dbg!(&sc.derive().await);
@@ -131,12 +131,12 @@ async fn main() -> Result<(), Error> {
 
                 TapSignerCommand::Backup => {
                     let response = &ts.backup(&cvc()).await;
-                    println!("{:?}", response);
+                    println!("{response:?}");
                 }
 
                 TapSignerCommand::Change { new_cvc } => {
                     let response = &ts.change(&new_cvc, &cvc()).await;
-                    println!("{:?}", response);
+                    println!("{response:?}");
                 }
                 TapSignerCommand::Sign { to_sign } => {
                     let digest: [u8; 32] =
@@ -144,7 +144,7 @@ async fn main() -> Result<(), Error> {
                             .to_byte_array();
 
                     let response = &ts.sign(digest, vec![], &cvc()).await;
-                    println!("{:?}", response);
+                    println!("{response:?}");
                 }
             }
         }
@@ -174,7 +174,7 @@ where
     C: Read<T>,
 {
     match card.read(cvc).await {
-        Ok(resp) => println!("{}", resp),
+        Ok(resp) => println!("{resp}"),
         Err(e) => {
             dbg!(&e);
             println!("Failed to read with error: ")

--- a/lib/src/apdu.rs
+++ b/lib/src/apdu.rs
@@ -848,8 +848,8 @@ impl fmt::Display for UnsealResponse {
         let pubkey = PublicKey::from_slice(self.pubkey.as_slice()).unwrap();
         let privkey = SecretKey::from_slice(self.privkey.as_slice()).unwrap();
         writeln!(f, "slot: {}", self.slot)?;
-        writeln!(f, "master_pk: {}", master)?;
-        writeln!(f, "pubkey: {}", pubkey)?;
+        writeln!(f, "master_pk: {master}")?;
+        writeln!(f, "pubkey: {pubkey}")?;
         writeln!(f, "privkey: {}", privkey.display_secret())
     }
 }

--- a/lib/src/factory_root_key.rs
+++ b/lib/src/factory_root_key.rs
@@ -44,10 +44,10 @@ impl Debug for FactoryRootKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             FactoryRootKey::Pub(pk) => {
-                write!(f, "FactoryRootKey::Pub({:?})", pk)
+                write!(f, "FactoryRootKey::Pub({pk:?})")
             }
             FactoryRootKey::Dev(pk) => {
-                write!(f, "FactoryRootKey::Dev({:?})", pk)
+                write!(f, "FactoryRootKey::Dev({pk:?})")
             }
         }
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -33,13 +33,13 @@ impl<T: CkTransport> core::fmt::Debug for CkTapCard<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
             CkTapCard::TapSigner(t) => {
-                write!(f, "CkTap::TapSigner({:?})", t)
+                write!(f, "CkTap::TapSigner({t:?})")
             }
             CkTapCard::SatsChip(t) => {
-                write!(f, "CkTap::SatsChip({:?})", t)
+                write!(f, "CkTap::SatsChip({t:?})")
             }
             CkTapCard::SatsCard(s) => {
-                write!(f, "CkTap::SatsCard({:?})", s)
+                write!(f, "CkTap::SatsCard({s:?})")
             }
         }
     }


### PR DESCRIPTION
### Description

Fix [clippy::uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)

Just ran `cargo clippy --fix` using clippy `0.1.88 (6b00bc3880 2025-06-23)`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing