### PR TITLE
feat(cli): add wait commands

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,7 +7,12 @@ pub mod apdu;
 pub mod commands;
 pub mod factory_root_key;
 
-pub use bitcoin::secp256k1::{self, rand};
+pub use bitcoin::{
+    Address, Network,
+    key::CompressedPublicKey,
+    key::UntweakedPublicKey,
+    secp256k1::{self, rand},
+};
 
 #[cfg(feature = "emulator")]
 pub mod emulator;

--- a/lib/src/sats_card.rs
+++ b/lib/src/sats_card.rs
@@ -145,7 +145,6 @@ impl<T: CkTransport> SatsCard<T> {
     }
 
     pub async fn address(&mut self) -> Result<String, Error> {
-        // TODO: support testnet
         let network = Network::Bitcoin;
         let slot_pubkey = self.read(None).await?.pubkey;
         let pk = BitcoinPublicKey::from_slice(&slot_pubkey)?;


### PR DESCRIPTION
### Description

I added a cli `wait` command for TAPSIGNER, SATSCHIP, and SATSCARD to help test recovering from a bad CVC. 

### Notes to the reviewers

I manually tested the `wait` command on all three card types.  We haven't implemented a cli command for SATSCARD to sign a TX after `unwrap` ing the private key for a slot so I haven't tested that yet.

Note: The SATSCARD can only sign for UTXOs send to `p2wpkh` addresses. The SATSCARD reveals the original secret key when a slot is unsealed and that can be used to sign for different script types but it's better to let the card do the signing and to stick with the `p2wpkh` script type other wallets will use for these cards. 

### Changelog notice

* Add cli `wait` command

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

