### PR TITLE
Add support for 'nfc'  and 'xpub' commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,9 +28,13 @@ help:
 
 # start the cktap emulator on /tmp/ecard-pipe
 start *OPTS: setup
-    source emulator_env/bin/activate; python3 coinkite/coinkite-tap-proto/emulator/ecard.py emulate {{OPTS}} &> emulator_env/output.log & \
-    echo $! > emulator_env/ecard.pid
-    echo "started emulator, pid:" `cat emulator_env/ecard.pid`
+    if [ -f emulator_env/ecard.pid ]; then \
+        echo "Emulator already running, pid:" `cat emulator_env/ecard.pid`; \
+    else \
+        source emulator_env/bin/activate; python3 coinkite/coinkite-tap-proto/emulator/ecard.py emulate {{OPTS}} &> emulator_env/output.log & \
+        echo $! > emulator_env/ecard.pid; \
+        echo "started emulator, pid:" `cat emulator_env/ecard.pid`; \
+    fi
 
 # stop the cktap emulator
 stop:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It is up to the crate user to send and receive the raw cktap APDU messages via N
 #### TAPSIGNER-Only Commands
 
 - [x] [change](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#change)
-- [ ] [xpub](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#xpub)
+- [x] [xpub](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#xpub)
 - [x] [backup](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#backup)
 
 ### Automated and CLI Testing with Emulator

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is up to the crate user to send and receive the raw cktap APDU messages via N
   - [ ] response verification
 - [x] [certs](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#certs)
 - [x] [new](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#new)
-- [ ] [nfc](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#nfc)
+- [x] [nfc](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#nfc)
 - [x] [sign](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#sign)
   - [x] response verification
 - [x] [wait](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#wait)

--- a/cktap-ffi/src/error.rs
+++ b/cktap-ffi/src/error.rs
@@ -376,3 +376,26 @@ impl From<rust_cktap::ChangeError> for ChangeError {
         }
     }
 }
+
+/// Errors returned by the `xpub` command.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error, uniffi::Error)]
+pub enum XpubError {
+    #[error(transparent)]
+    CkTap {
+        #[from]
+        err: CkTapError,
+    },
+    #[error("BIP32 error: {msg}")]
+    Bip32 { msg: String },
+}
+
+impl From<rust_cktap::XpubError> for XpubError {
+    fn from(value: rust_cktap::XpubError) -> Self {
+        match value {
+            rust_cktap::XpubError::CkTap(err) => XpubError::CkTap { err: err.into() },
+            rust_cktap::XpubError::Bip32(err) => XpubError::Bip32 {
+                msg: err.to_string(),
+            },
+        }
+    }
+}

--- a/cktap-ffi/src/lib.rs
+++ b/cktap-ffi/src/lib.rs
@@ -18,7 +18,7 @@ use futures::lock::Mutex;
 use rust_cktap::Network;
 use rust_cktap::shared::FactoryRootKey;
 use rust_cktap::shared::{Certificate, Read};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -119,6 +119,24 @@ impl Psbt {
 
     pub fn to_base64(&self) -> String {
         self.inner.to_string()
+    }
+}
+
+#[derive(uniffi::Object, Clone, Eq, PartialEq)]
+pub struct Xpub {
+    inner: rust_cktap::Xpub,
+}
+
+#[uniffi::export]
+impl Xpub {
+    pub fn encode(&self) -> Vec<u8> {
+        self.inner.encode().to_vec()
+    }
+}
+
+impl Display for Xpub {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
     }
 }
 

--- a/cktap-ffi/src/sats_card.rs
+++ b/cktap-ffi/src/sats_card.rs
@@ -6,7 +6,7 @@ use crate::error::{
 };
 use crate::{ChainCode, PrivateKey, Psbt, PublicKey, check_cert, read};
 use futures::lock::Mutex;
-use rust_cktap::shared::{Authentication, Wait};
+use rust_cktap::shared::{Authentication, Nfc, Wait};
 use std::sync::Arc;
 
 #[derive(uniffi::Object)]
@@ -126,5 +126,11 @@ impl SatsCard {
             .await
             .map(|psbt| Psbt { inner: psbt })?;
         Ok(psbt)
+    }
+
+    pub async fn nfc(&self) -> Result<String, CkTapError> {
+        let mut card = self.0.lock().await;
+        let url = card.nfc().await?;
+        Ok(url)
     }
 }

--- a/cktap-ffi/src/sats_chip.rs
+++ b/cktap-ffi/src/sats_chip.rs
@@ -1,11 +1,14 @@
 // Copyright (c) 2025 rust-cktap contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::error::{CertsError, ChangeError, CkTapError, DeriveError, ReadError, SignPsbtError};
+use crate::error::{
+    CertsError, ChangeError, CkTapError, DeriveError, ReadError, SignPsbtError, XpubError,
+};
 use crate::tap_signer::{change, derive, init, sign_psbt};
-use crate::{ChainCode, Psbt, PublicKey, check_cert, read};
+use crate::{ChainCode, Psbt, PublicKey, Xpub, check_cert, read};
 use futures::lock::Mutex;
 use rust_cktap::shared::{Authentication, Nfc, Wait};
+use rust_cktap::tap_signer::TapSignerShared;
 use std::sync::Arc;
 
 #[derive(uniffi::Object)]
@@ -84,5 +87,11 @@ impl SatsChip {
         let mut card = self.0.lock().await;
         let url = card.nfc().await?;
         Ok(url)
+    }
+
+    pub async fn xpub(&self, master: bool, cvc: String) -> Result<Xpub, XpubError> {
+        let mut card = self.0.lock().await;
+        let xpub = card.xpub(master, &cvc).await?;
+        Ok(Xpub { inner: xpub })
     }
 }

--- a/cktap-ffi/src/sats_chip.rs
+++ b/cktap-ffi/src/sats_chip.rs
@@ -5,7 +5,7 @@ use crate::error::{CertsError, ChangeError, CkTapError, DeriveError, ReadError, 
 use crate::tap_signer::{change, derive, init, sign_psbt};
 use crate::{ChainCode, Psbt, PublicKey, check_cert, read};
 use futures::lock::Mutex;
-use rust_cktap::shared::{Authentication, Wait};
+use rust_cktap::shared::{Authentication, Nfc, Wait};
 use std::sync::Arc;
 
 #[derive(uniffi::Object)]
@@ -78,5 +78,11 @@ impl SatsChip {
         let mut card = self.0.lock().await;
         change(&mut *card, new_cvc, cvc).await?;
         Ok(())
+    }
+
+    pub async fn nfc(&self) -> Result<String, CkTapError> {
+        let mut card = self.0.lock().await;
+        let url = card.nfc().await?;
+        Ok(url)
     }
 }

--- a/cktap-ffi/src/tap_signer.rs
+++ b/cktap-ffi/src/tap_signer.rs
@@ -1,8 +1,10 @@
 // Copyright (c) 2025 rust-cktap contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::error::{CertsError, ChangeError, CkTapError, DeriveError, ReadError, SignPsbtError};
-use crate::{ChainCode, Psbt, PublicKey, check_cert, read};
+use crate::error::{
+    CertsError, ChangeError, CkTapError, DeriveError, ReadError, SignPsbtError, XpubError,
+};
+use crate::{ChainCode, Psbt, PublicKey, Xpub, check_cert, read};
 use futures::lock::Mutex;
 use rust_cktap::shared::{Authentication, Nfc, Wait};
 use rust_cktap::tap_signer::TapSignerShared;
@@ -86,6 +88,12 @@ impl TapSigner {
         let mut card = self.0.lock().await;
         let url = card.nfc().await?;
         Ok(url)
+    }
+
+    pub async fn xpub(&self, master: bool, cvc: String) -> Result<Xpub, XpubError> {
+        let mut card = self.0.lock().await;
+        let xpub = card.xpub(master, &cvc).await?;
+        Ok(Xpub { inner: xpub })
     }
 }
 

--- a/cktap-ffi/src/tap_signer.rs
+++ b/cktap-ffi/src/tap_signer.rs
@@ -4,7 +4,7 @@
 use crate::error::{CertsError, ChangeError, CkTapError, DeriveError, ReadError, SignPsbtError};
 use crate::{ChainCode, Psbt, PublicKey, check_cert, read};
 use futures::lock::Mutex;
-use rust_cktap::shared::{Authentication, Wait};
+use rust_cktap::shared::{Authentication, Nfc, Wait};
 use rust_cktap::tap_signer::TapSignerShared;
 use std::sync::Arc;
 
@@ -80,6 +80,12 @@ impl TapSigner {
         let mut card = self.0.lock().await;
         change(&mut *card, new_cvc, cvc).await?;
         Ok(())
+    }
+
+    pub async fn nfc(&self) -> Result<String, CkTapError> {
+        let mut card = self.0.lock().await;
+        let url = card.nfc().await?;
+        Ok(url)
     }
 }
 

--- a/cktap-swift/Tests/CKTapTests/CKTapTests.swift
+++ b/cktap-swift/Tests/CKTapTests/CKTapTests.swift
@@ -29,4 +29,19 @@ final class CKTapTests: XCTestCase {
       XCTAssertEqual(status.ver, "1.0.3")
     }
   }
+  func testNfcUrl() async throws {
+    let cardEmulator = CardEmulator()
+    let card = try await toCktap(transport: cardEmulator)
+    switch card {
+        case .satsCard(let satsCard):
+          let url: String = try await satsCard.nfc()
+          print("SatsCard url: \(url)")
+        case .tapSigner(let tapSigner):
+          let url: String = try await tapSigner.nfc()
+          print("TapSigner url: \(url)")
+        case .satsChip(let satsChip):
+          let url: String = try await satsChip.nfc()
+          print("SatsChip url: \(url)")
+        }
+  }
 }

--- a/cktap-swift/Tests/CKTapTests/CKTapTests.swift
+++ b/cktap-swift/Tests/CKTapTests/CKTapTests.swift
@@ -33,15 +33,29 @@ final class CKTapTests: XCTestCase {
     let cardEmulator = CardEmulator()
     let card = try await toCktap(transport: cardEmulator)
     switch card {
-        case .satsCard(let satsCard):
-          let url: String = try await satsCard.nfc()
-          print("SatsCard url: \(url)")
-        case .tapSigner(let tapSigner):
-          let url: String = try await tapSigner.nfc()
-          print("TapSigner url: \(url)")
-        case .satsChip(let satsChip):
-          let url: String = try await satsChip.nfc()
-          print("SatsChip url: \(url)")
-        }
+    case .satsCard(let satsCard):
+      let url: String = try await satsCard.nfc()
+      print("SatsCard url: \(url)")
+    case .tapSigner(let tapSigner):
+      let url: String = try await tapSigner.nfc()
+      print("TapSigner url: \(url)")
+    case .satsChip(let satsChip):
+      let url: String = try await satsChip.nfc()
+      print("SatsChip url: \(url)")
+    }
+  }
+  func testXpub() async throws {
+    let cardEmulator = CardEmulator()
+    let card = try await toCktap(transport: cardEmulator)
+    switch card {
+    case .satsCard(_):
+      print("SatsCard does not support he xpub command.")
+    case .tapSigner(let tapSigner):
+      let xpub: String = try await tapSigner.xpub(master: true, cvc: "123456").toString()
+      print("TapSigner master xpub: \(xpub)")
+    case .satsChip(let satsChip):
+      let xpub: String = try await satsChip.xpub(master: false, cvc: "123456").toString()
+      print("SatsChip xpub: \(xpub)")
+    }
   }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -108,8 +108,8 @@ enum TapSignerCommand {
     Backup,
     /// Change the PIN (CVC) used for card authentication to a new user provided one
     Change { new_cvc: String },
-    /// Sign a digest
-    Sign { to_sign: String },
+    /// Sign a PSBT
+    Sign { psbt: String },
     /// Call wait command until no auth delay
     Wait,
     /// Get the card's nfc URL
@@ -150,8 +150,8 @@ enum SatsChipCommand {
     },
     /// Change the PIN (CVC) used for card authentication to a new user provided one
     Change { new_cvc: String },
-    /// Sign a digest
-    Sign { to_sign: String },
+    /// Sign a PSBT
+    Sign { psbt: String },
     /// Call wait command until no auth delay
     Wait,
     /// Get the card's nfc URL
@@ -241,12 +241,10 @@ async fn main() -> Result<(), CliError> {
                     let response = &ts.change(&new_cvc, &cvc()).await;
                     println!("{response:?}");
                 }
-                TapSignerCommand::Sign { to_sign } => {
-                    let digest: [u8; 32] =
-                        rust_cktap::Hash::hash(to_sign.as_bytes()).to_byte_array();
-
-                    let response = &ts.sign(digest, vec![], &cvc()).await;
-                    println!("{response:?}");
+                TapSignerCommand::Sign { psbt } => {
+                    let psbt = Psbt::from_str(&psbt)?;
+                    let signed_psbt = ts.sign_psbt(psbt, &cvc()).await?;
+                    println!("signed_psbt: {signed_psbt}");
                 }
                 TapSignerCommand::Wait => wait(ts).await,
                 TapSignerCommand::Nfc => nfc(ts).await,
@@ -274,12 +272,10 @@ async fn main() -> Result<(), CliError> {
                     let response = &sc.change(&new_cvc, &cvc()).await;
                     println!("{response:?}");
                 }
-                SatsChipCommand::Sign { to_sign } => {
-                    let digest: [u8; 32] =
-                        rust_cktap::Hash::hash(to_sign.as_bytes()).to_byte_array();
-
-                    let response = &sc.sign(digest, vec![], &cvc()).await;
-                    println!("{response:?}");
+                SatsChipCommand::Sign { psbt } => {
+                    let psbt = Psbt::from_str(&psbt)?;
+                    let signed_psbt = sc.sign_psbt(psbt, &cvc()).await?;
+                    println!("signed_psbt: {signed_psbt}");
                 }
                 SatsChipCommand::Wait => wait(sc).await,
                 SatsChipCommand::Nfc => nfc(sc).await,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -358,5 +358,5 @@ where
     dbg!(master);
     let xpub = card.xpub(master, &cvc()).await.expect("xpub failed");
     dbg!(&xpub);
-    println!("{}", xpub.to_string());
+    println!("{xpub}");
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,7 @@ use rust_cktap::emulator;
 use rust_cktap::error::{DumpError, StatusError, UnsealError};
 #[cfg(not(feature = "emulator"))]
 use rust_cktap::pcsc;
-use rust_cktap::shared::{Authentication, Read, Wait};
+use rust_cktap::shared::{Authentication, Nfc, Read, Wait};
 use rust_cktap::tap_signer::TapSignerShared;
 use rust_cktap::{
     CkTapCard, CkTapError, Psbt, PsbtParseError, SignPsbtError, rand_chaincode, shared::Certificate,
@@ -74,6 +74,8 @@ enum SatsCardCommand {
     },
     /// Call wait command until no auth delay
     Wait,
+    /// Get the card's nfc URL
+    Nfc,
 }
 
 /// TapSigner CLI
@@ -110,6 +112,8 @@ enum TapSignerCommand {
     Sign { to_sign: String },
     /// Call wait command until no auth delay
     Wait,
+    /// Get the card's nfc URL
+    Nfc,
 }
 
 /// TapSigner CLI
@@ -144,6 +148,8 @@ enum SatsChipCommand {
     Sign { to_sign: String },
     /// Call wait command until no auth delay
     Wait,
+    /// Get the card's nfc URL
+    Nfc,
 }
 
 #[tokio::main]
@@ -192,6 +198,7 @@ async fn main() -> Result<(), CliError> {
                     dbg!(response);
                 }
                 SatsCardCommand::Wait => wait(sc).await,
+                SatsCardCommand::Nfc => nfc(sc).await,
             }
         }
         CkTapCard::TapSigner(ts) => {
@@ -230,6 +237,7 @@ async fn main() -> Result<(), CliError> {
                     println!("{response:?}");
                 }
                 TapSignerCommand::Wait => wait(ts).await,
+                TapSignerCommand::Nfc => nfc(ts).await,
             }
         }
         CkTapCard::SatsChip(sc) => {
@@ -261,6 +269,7 @@ async fn main() -> Result<(), CliError> {
                     println!("{response:?}");
                 }
                 SatsChipCommand::Wait => wait(sc).await,
+                SatsChipCommand::Nfc => nfc(sc).await,
             }
         }
     }
@@ -318,4 +327,12 @@ where
         println!();
     }
     println!("No auth delay.");
+}
+
+async fn nfc<C>(card: &mut C)
+where
+    C: Nfc + Send,
+{
+    let nfc = card.nfc().await.expect("nfc failed");
+    println!("{nfc}");
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,6 +114,12 @@ enum TapSignerCommand {
     Wait,
     /// Get the card's nfc URL
     Nfc,
+    /// Read the xpub (requires CVC)
+    Xpub {
+        /// Give master (`m`) XPUB, otherwise derived XPUB
+        #[clap(short, long)]
+        master: bool,
+    },
 }
 
 /// TapSigner CLI
@@ -150,6 +156,12 @@ enum SatsChipCommand {
     Wait,
     /// Get the card's nfc URL
     Nfc,
+    /// Read the xpub (requires CVC)
+    Xpub {
+        /// Give master (`m`) XPUB, otherwise derived XPUB
+        #[clap(short, long)]
+        master: bool,
+    },
 }
 
 #[tokio::main]
@@ -238,6 +250,7 @@ async fn main() -> Result<(), CliError> {
                 }
                 TapSignerCommand::Wait => wait(ts).await,
                 TapSignerCommand::Nfc => nfc(ts).await,
+                TapSignerCommand::Xpub { master } => xpub(ts, master).await,
             }
         }
         CkTapCard::SatsChip(sc) => {
@@ -270,6 +283,7 @@ async fn main() -> Result<(), CliError> {
                 }
                 SatsChipCommand::Wait => wait(sc).await,
                 SatsChipCommand::Nfc => nfc(sc).await,
+                SatsChipCommand::Xpub { master } => xpub(sc, master).await,
             }
         }
     }
@@ -335,4 +349,14 @@ where
 {
     let nfc = card.nfc().await.expect("nfc failed");
     println!("{nfc}");
+}
+
+async fn xpub<C>(card: &mut C, master: bool)
+where
+    C: TapSignerShared + Send,
+{
+    dbg!(master);
+    let xpub = card.xpub(master, &cvc()).await.expect("xpub failed");
+    dbg!(&xpub);
+    println!("{}", xpub.to_string());
 }

--- a/lib/src/apdu.rs
+++ b/lib/src/apdu.rs
@@ -468,7 +468,7 @@ impl CommandApdu for NfcCommand {
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct NfcResponse {
     /// command result
-    url: String,
+    pub url: String,
 }
 
 impl ResponseApdu for NfcResponse {}

--- a/lib/src/apdu/tap_signer.rs
+++ b/lib/src/apdu/tap_signer.rs
@@ -8,7 +8,6 @@ use bitcoin::secp256k1;
 use bitcoin_hashes::hex::DisplayHex as _;
 use serde::{Deserialize, Serialize};
 
-// MARK: - XpubCommand
 /// TAPSIGNER only - Provides the current XPUB (BIP-32 serialized), either at the top level (master)
 /// or the derived key in use (see 'path' value in status response)
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
@@ -28,7 +27,6 @@ impl CommandApdu for XpubCommand {
 }
 
 impl XpubCommand {
-    #[allow(unused)] // TODO this needs to be used
     pub fn new(master: bool, epubkey: secp256k1::PublicKey, xcvc: Vec<u8>) -> Self {
         Self {
             cmd: Self::name(),
@@ -42,9 +40,9 @@ impl XpubCommand {
 #[derive(Deserialize, Clone)]
 pub struct XpubResponse {
     #[serde(with = "serde_bytes")]
-    xpub: Vec<u8>,
+    pub xpub: Vec<u8>,
     #[serde(with = "serde_bytes")]
-    card_nonce: [u8; 16],
+    pub card_nonce: [u8; 16],
 }
 
 impl ResponseApdu for XpubResponse {}
@@ -58,7 +56,6 @@ impl std::fmt::Debug for XpubResponse {
     }
 }
 
-// MARK: - ChangeCommand
 /// TAPSIGNER only - Change the PIN (CVC) used for card authentication to a new user provided one
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct ChangeCommand {
@@ -104,7 +101,6 @@ pub struct ChangeResponse {
 
 impl ResponseApdu for ChangeResponse {}
 
-// MARK: - BackupCommand
 /// TAPSIGNER only - Get an encrypted backup of the card's private key
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -185,6 +185,15 @@ pub enum DeriveError {
     InvalidChainCode(String),
 }
 
+/// Errors returned by the `xpub` command.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum XpubError {
+    #[error(transparent)]
+    CkTap(#[from] CkTapError),
+    #[error(transparent)]
+    Bip32(#[from] bitcoin::bip32::Error),
+}
+
 /// Errors returned by the `unseal` command.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum UnsealError {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,12 +7,12 @@ pub use bitcoin::bip32::ChainCode;
 pub use bitcoin::key::FromSliceError;
 pub use bitcoin::psbt::{Psbt, PsbtParseError};
 pub use bitcoin::secp256k1::{Error as SecpError, rand};
-pub use bitcoin::{Network, PrivateKey, PublicKey};
+pub use bitcoin::{Network, PrivateKey, PublicKey, bip32::Xpub};
 pub use bitcoin_hashes::sha256::Hash;
 
 pub use error::{
     CardError, CertsError, ChangeError, CkTapError, DeriveError, DumpError, ReadError,
-    SignPsbtError, StatusError, UnsealError,
+    SignPsbtError, StatusError, UnsealError, XpubError,
 };
 pub use shared::CkTransport;
 

--- a/lib/src/sats_card.rs
+++ b/lib/src/sats_card.rs
@@ -8,7 +8,7 @@ use crate::apdu::{
 };
 use crate::error::{CardError, DeriveError, DumpError, ReadError, UnsealError};
 use crate::error::{SignPsbtError, StatusError};
-use crate::shared::{Authentication, Certificate, CkTransport, Read, Wait, transmit};
+use crate::shared::{Authentication, Certificate, CkTransport, Nfc, Read, Wait, transmit};
 use async_trait::async_trait;
 use bitcoin::bip32::{ChainCode, DerivationPath, Fingerprint, Xpub};
 use bitcoin::secp256k1;
@@ -421,6 +421,9 @@ impl Certificate for SatsCard {
         Ok(Some(pubkey))
     }
 }
+
+#[async_trait]
+impl Nfc for SatsCard {}
 
 impl core::fmt::Debug for SatsCard {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/lib/src/sats_chip.rs
+++ b/lib/src/sats_chip.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use crate::apdu::StatusResponse;
 use crate::error::{ReadError, StatusError};
-use crate::shared::{Authentication, Certificate, CkTransport, Read, Wait};
+use crate::shared::{Authentication, Certificate, CkTransport, Nfc, Read, Wait};
 use crate::tap_signer::TapSignerShared;
 
 /// - SATSCHIP model: this product variant is a TAPSIGNER in all respects,
@@ -109,6 +109,9 @@ impl Certificate for SatsChip {
         Ok(None)
     }
 }
+
+#[async_trait]
+impl Nfc for SatsChip {}
 
 impl core::fmt::Debug for SatsChip {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/lib/src/tap_signer.rs
+++ b/lib/src/tap_signer.rs
@@ -316,7 +316,7 @@ pub trait TapSignerShared: Authentication {
         Ok(())
     }
 
-    async fn xpub(&mut self, cvc: &str, master: bool) -> Result<Xpub, XpubError> {
+    async fn xpub(&mut self, master: bool, cvc: &str) -> Result<Xpub, XpubError> {
         let (_, epubkey, xcvc) = self.calc_ekeys_xcvc(cvc, XpubCommand::name());
         let xpub_command = XpubCommand::new(master, epubkey, xcvc);
         let xpub_response: XpubResponse = transmit(self.transport(), &xpub_command).await?;
@@ -420,9 +420,9 @@ mod test {
         let emulator = find_emulator(pipe_path).await.unwrap();
         if let CkTapCard::TapSigner(mut ts) = emulator {
             ts.init(rand_chaincode(), "123456").await.unwrap();
-            let xpub = ts.xpub("123456", false).await.unwrap();
+            let xpub = ts.xpub(false, "123456").await.unwrap();
             assert_eq!(xpub.depth, 3);
-            let master_xpub = ts.xpub("123456", true).await.unwrap();
+            let master_xpub = ts.xpub(true, "123456").await.unwrap();
             assert_eq!(master_xpub.depth, 0);
         }
         drop(python);

--- a/lib/src/tap_signer.rs
+++ b/lib/src/tap_signer.rs
@@ -7,7 +7,7 @@ use crate::apdu::{
     tap_signer::{BackupCommand, BackupResponse, ChangeCommand, ChangeResponse},
 };
 use crate::error::{ChangeError, DeriveError, ReadError, SignPsbtError, StatusError};
-use crate::shared::{Authentication, Certificate, CkTransport, Read, Wait, transmit};
+use crate::shared::{Authentication, Certificate, CkTransport, Nfc, Read, Wait, transmit};
 use crate::{BIP32_HARDENED_MASK, CkTapError};
 use async_trait::async_trait;
 use bitcoin::PublicKey;
@@ -315,6 +315,9 @@ pub trait TapSignerShared: Authentication {
         Ok(())
     }
 }
+
+#[async_trait]
+impl Nfc for TapSigner {}
 
 impl TapSignerShared for TapSigner {}
 


### PR DESCRIPTION
### Description

Add support for the 'nfc' and 'xpub' commands in the lib, cli, and ffi bindings. Updates cli `sign` for  TAPSIGNER and SATSCHIP to sign a PSBT instead of a message.

Closes: #16 
Closes: #17

### Notes to the reviewers

This is based on #46 and I'll rebase after that PR is merged.

### Changelog notice

- Add support for `nfc` and `xpub` commands in the lib, cli, and ffi bindings.
- Change cli `sign` command for TAPSIGNER and SATSCHIP to sign a PSBT instead of a digest.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
