### PR TITLE
Increase the ChangeError len values to u32

### DIFF
--- a/cktap-ffi/src/error.rs
+++ b/cktap-ffi/src/error.rs
@@ -345,9 +345,9 @@ pub enum ChangeError {
         err: CkTapError,
     },
     #[error("new cvc is too short, must be at least 6 bytes, was only {len} bytes")]
-    TooShort { len: u8 },
+    TooShort { len: u32 },
     #[error("new cvc is too long, must be at most 32 bytes, was {len} bytes")]
-    TooLong { len: u8 },
+    TooLong { len: u32 },
     #[error("new cvc is the same as the old one")]
     SameAsOld,
 }

--- a/cktap-swift/Sources/CKTap/cktap_ffi.swift
+++ b/cktap-swift/Sources/CKTap/cktap_ffi.swift
@@ -2019,9 +2019,9 @@ enum ChangeError: Swift.Error, Equatable, Hashable, Foundation.LocalizedError {
     
     case CkTap(err: CkTapError
     )
-    case TooShort(len: UInt8
+    case TooShort(len: UInt32
     )
-    case TooLong(len: UInt8
+    case TooLong(len: UInt32
     )
     case SameAsOld
 
@@ -2057,10 +2057,10 @@ public struct FfiConverterTypeChangeError: FfiConverterRustBuffer {
             err: try FfiConverterTypeCkTapError.read(from: &buf)
             )
         case 2: return .TooShort(
-            len: try FfiConverterUInt8.read(from: &buf)
+            len: try FfiConverterUInt32.read(from: &buf)
             )
         case 3: return .TooLong(
-            len: try FfiConverterUInt8.read(from: &buf)
+            len: try FfiConverterUInt32.read(from: &buf)
             )
         case 4: return .SameAsOld
 
@@ -2082,12 +2082,12 @@ public struct FfiConverterTypeChangeError: FfiConverterRustBuffer {
         
         case let .TooShort(len):
             writeInt(&buf, Int32(2))
-            FfiConverterUInt8.write(len, into: &buf)
+            FfiConverterUInt32.write(len, into: &buf)
             
         
         case let .TooLong(len):
             writeInt(&buf, Int32(3))
-            FfiConverterUInt8.write(len, into: &buf)
+            FfiConverterUInt32.write(len, into: &buf)
             
         
         case .SameAsOld:

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -131,9 +131,9 @@ pub enum ChangeError {
     #[error(transparent)]
     CkTap(#[from] CkTapError),
     #[error("new cvc is too short, must be at least 6 bytes, was only {0} bytes")]
-    TooShort(u8),
+    TooShort(u32),
     #[error("new cvc is too long, must be at most 32 bytes, was {0} bytes")]
-    TooLong(u8),
+    TooLong(u32),
     #[error("new cvc is the same as the old one")]
     SameAsOld,
 }

--- a/lib/src/tap_signer.rs
+++ b/lib/src/tap_signer.rs
@@ -286,11 +286,11 @@ pub trait TapSignerShared: Authentication {
     /// Change the CVC used for card authentication to a new user provided one
     async fn change(&mut self, new_cvc: &str, cvc: &str) -> Result<(), ChangeError> {
         if new_cvc.len() < 6 {
-            return Err(ChangeError::TooShort(new_cvc.len() as u8));
+            return Err(ChangeError::TooShort(new_cvc.len() as u32));
         }
 
         if new_cvc.len() > 32 {
-            return Err(ChangeError::TooLong(new_cvc.len() as u8));
+            return Err(ChangeError::TooLong(new_cvc.len() as u32));
         }
 
         if new_cvc == cvc {


### PR DESCRIPTION
### Description

Fixes issue mentioned in https://github.com/bitcoindevkit/rust-cktap/pull/65#discussion_r3052809553.

I confirmed that if a too long CVC is used then an incorrect `len` value is returned. After the fix in this PR any CVC less than 2^32 in length will return an error with the actual inputted incorrect CVC length.

### Notes to the reviewers

I tested before and after this change with the cli tool and an emulated TAPSIGNER card.

This is a BREAKING CHANGE.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/notmandatory/rust-cktap/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
